### PR TITLE
Restructure links to dh.page

### DIFF
--- a/playwright-tests/tests/addons.spec.js
+++ b/playwright-tests/tests/addons.spec.js
@@ -7,7 +7,7 @@ test.describe("Wallet is connected", () => {
 
   test.describe("AddonsConfigurator", () => {
     const baseUrl =
-      "/devgovgigs.near/widget/app?page=community.configuration&handle=devhub-test";
+      "/devhub.near/widget/dh.community.configuration?handle=devhub-test";
     // const dropdownSelector =
     //   'input[data-component="near/widget/DIG.InputSelect"]';
     // const addButtonSelector = "button.btn-success:has(i.bi.bi-plus)";

--- a/playwright-tests/tests/admin.spec.js
+++ b/playwright-tests/tests/admin.spec.js
@@ -9,7 +9,7 @@ test.describe("Wallet is connected", () => {
   test("should be able to manage featured communities from home page settings tab", async ({
     page,
   }) => {
-    await page.goto("/devhub.near/widget/app?page=admin");
+    await page.goto("/devhub.near/widget/dh.admin");
 
     const buttonSelector = `button[data-testid="preview-homepage"]`;
     // Wait for the first post history button to be visible
@@ -42,7 +42,7 @@ test.describe("Wallet is connected", () => {
   });
 
   test("should be able to manage moderators", async ({ page }) => {
-    await page.goto("/devhub.near/widget/app?page=admin");
+    await page.goto("/devhub.near/widget/dh.admin");
     const buttonSelector = `button[data-testid="preview-homepage"]`;
     // Wait for the first post button to be visible
     await page.waitForSelector(buttonSelector, {
@@ -72,7 +72,7 @@ test.describe("Wallet is connected", () => {
   });
 
   test("should be able to manage restricted labels", async ({ page }) => {
-    await page.goto("/devhub.near/widget/app?page=admin");
+    await page.goto("/devhub.near/widget/dh.admin");
     const buttonSelector = `button[data-testid="preview-homepage"]`;
     // Wait for the first post button to be visible
     await page.waitForSelector(buttonSelector, {
@@ -171,7 +171,7 @@ test.describe("Wallet is connected", () => {
   test("shouldn't be able to add a none existing community handle without a warning", async ({
     page,
   }) => {
-    await page.goto("/devhub.near/widget/app?page=admin");
+    await page.goto("/devhub.near/widget/dh.admin");
     const buttonSelector = `button[data-testid="preview-homepage"]`;
     // Wait for the first post  button to be visible
     await page.waitForSelector(buttonSelector, {
@@ -199,7 +199,7 @@ test.describe("Wallet is not connect", () => {
   test("should show banner that the user doesn't have access", async ({
     page,
   }) => {
-    await page.goto("/devhub.near/widget/app?page=admin");
+    await page.goto("/devhub.near/widget/dh.admin");
     const buttonSelector = "h2.alert.alert-danger";
     // Wait for the first post history button to be visible
 

--- a/playwright-tests/tests/admin.spec.js
+++ b/playwright-tests/tests/admin.spec.js
@@ -51,23 +51,25 @@ test.describe("Wallet is connected", () => {
 
     await page.getByRole("tab", { name: "Moderators" }).click();
     await page.getByTestId("edit-members").click();
-    await page.locator("div:nth-child(9)").click();
+    await page.locator("div:nth-child(3) > div:nth-child(7)").click();
     await page
       .locator(
-        "div:nth-child(9) > div > .d-flex > .input-group > .form-control"
+        "div:nth-child(7) > div > .d-flex > .input-group > .form-control"
       )
       .click();
     await page
       .locator(
-        "div:nth-child(9) > div > .d-flex > .input-group > .form-control"
+        "div:nth-child(7) > div > .d-flex > .input-group > .form-control"
       )
-      .fill("thomasguntenaar.near");
+      .fill("test.near");
     await page.getByRole("button", { name: "" }).click();
     await page.getByRole("button", { name: " Submit" }).click();
-    await page.getByText("Close").click();
-    await page.getByRole("button", { name: "Cancel" }).click();
-    await page.getByTestId("edit-members").click();
-    await page.locator("div:nth-child(9)").click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+    await page.getByLabel("Close").click();
+    await page.locator("div:nth-child(3) > div:nth-child(7) > .btn").click();
+    await page.getByRole("button", { name: " Submit" }).click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+    await page.getByLabel("Close").click();
     await page.getByTestId("edit-members").click();
   });
 

--- a/playwright-tests/tests/communities.spec.js
+++ b/playwright-tests/tests/communities.spec.js
@@ -8,7 +8,7 @@ test.describe("Wallet is connected", () => {
   test("should show spawner when user clicks create community", async ({
     page,
   }) => {
-    await page.goto("/devgovgigs.near/widget/app?page=communities");
+    await page.goto("/devhub.near/widget/dh.communities");
 
     const createCommunityButtonSelector = 'button:has-text("Create Community")';
 
@@ -17,7 +17,7 @@ test.describe("Wallet is connected", () => {
     });
     await page.click(createCommunityButtonSelector);
 
-    const communitySpawnerSelector = 'div:has-text("Community information")';
+    const communitySpawnerSelector = 'div:has-text("Description")';
     await page.waitForSelector(communitySpawnerSelector, { state: "visible" });
   });
 });
@@ -28,7 +28,7 @@ test.describe("Wallet is not connected", () => {
   });
 
   test("spawner and button should not be visible", async ({ page }) => {
-    await page.goto("/devgovgigs.near/widget/app?page=communities");
+    await page.goto("/devhub.near/widget/dh.communities");
 
     const createCommunityButtonSelector = 'button:has-text("Create Community")';
 

--- a/playwright-tests/tests/community.spec.js
+++ b/playwright-tests/tests/community.spec.js
@@ -1,12 +1,10 @@
 import { test, expect } from "@playwright/test";
 
 test("should load a community page if handle exists", async ({ page }) => {
-  await page.goto(
-    "/devgovgigs.near/widget/app?page=community&handle=devhub-test"
-  );
+  await page.goto("/devhub.near/widget/dh.community?handle=devhub-test");
 
   // Using the <Link> that wraps the tabs to identify a community page loaded
-  const communityTabSelector = `a[href^="/devgovgigs.near/widget/app?page=community&handle=devhub-test&tab="]`;
+  const communityTabSelector = `a[href^="/devhub.near/widget/dh.community?handle=devhub-test&tab="]`;
 
   // Wait for the tab to be visible
   await page.waitForSelector(communityTabSelector, {
@@ -21,9 +19,7 @@ test("should load a community page if handle exists", async ({ page }) => {
 });
 
 test("should load an error page if handle does not exist", async ({ page }) => {
-  await page.goto(
-    "/devgovgigs.near/widget/app?page=community&handle=devhub-faketest"
-  );
+  await page.goto("/devhub.near/widget/dh.community?handle=devhub-faketest");
 
   // Using the <Link> that wraps the card to identify a community
   const communityNotFoundSelector =
@@ -43,9 +39,7 @@ test.describe("Wallet is connected", () => {
   test("should allow connected user to post from community page", async ({
     page,
   }) => {
-    await page.goto(
-      "/devgovgigs.near/widget/app?page=community&handle=devhub-test"
-    );
+    await page.goto("/devhub.near/widget/dh.community?handle=devhub-test");
 
     const postButtonSelector = 'a:has-text("Post")';
 
@@ -61,7 +55,7 @@ test.describe("Wallet is connected", () => {
 
     // Verify that the URL is the expected one.
     expect(page.url()).toBe(
-      "http://localhost:8080/devgovgigs.near/widget/app?page=create&labels=devhub-test"
+      "http://localhost:8080/devhub.near/widget/dh.create?labels=devhub-test"
     );
 
     // Wait for the Typeahead field to render.
@@ -90,9 +84,7 @@ test.describe("Wallet is not connected", () => {
   test("should not allow unconnected user to post from community page", async ({
     page,
   }) => {
-    await page.goto(
-      "/devgovgigs.near/widget/app?page=community&handle=devhub-test"
-    );
+    await page.goto("/devhub.near/widget/dh.community?handle=devhub-test");
 
     const createCommunityButtonSelector = 'button:has-text("Post")';
 

--- a/playwright-tests/tests/create.spec.js
+++ b/playwright-tests/tests/create.spec.js
@@ -4,7 +4,7 @@ import { setInputAndAssert, selectAndAssert } from "../testUtils";
 test("should be able to submit a solution with USDC as currency", async ({
   page,
 }) => {
-  await page.goto("/devgovgigs.near/widget/app?page=create");
+  await page.goto("/devhub.near/widget/dh.create");
 
   await page.click('button:has-text("Solution")');
 

--- a/playwright-tests/tests/feed.spec.js
+++ b/playwright-tests/tests/feed.spec.js
@@ -25,7 +25,7 @@ test("LEGACY: should show post history for posts in the feed", async ({
 });
 
 test("should show post history for posts in the feed", async ({ page }) => {
-  await page.goto("/devgovgigs.near/widget/app?page=feed");
+  await page.goto("/devhub.near/widget/dh.feed");
 
   const firstPostHistoryButtonSelector = 'a.card-link[title="Post History"]';
   // Wait for the first post history button to be visible
@@ -47,7 +47,7 @@ test("should show post history for posts in the feed", async ({ page }) => {
 
 test("should hide posts with devhub-test tag", async ({ page }) => {
   // go to feeds page
-  await page.goto("/devhub.near/widget/app?page=feed");
+  await page.goto("/devhub.near/widget/dh.feed");
 
   // look for tag input
   const tagInputSelector = 'input[placeholder="Search by tag"]';
@@ -76,7 +76,7 @@ test.describe("Wallet is connected", () => {
 
   test("should hide posts editor when hit cancel", async ({ page }) => {
     // go to feed with logged in user account
-    await page.goto("/devhub.near/widget/app?page=feed&author=efiz.near");
+    await page.goto("/devhub.near/widget/dh.feed?author=efiz.near");
 
     // find first post with edit button
     const firstPostWithEditButton = 'a.card-link[title="Edit post"]';

--- a/playwright-tests/tests/search.spec.js
+++ b/playwright-tests/tests/search.spec.js
@@ -1,7 +1,7 @@
 import { test } from "@playwright/test";
 
 test("should show post history for posts in the feed", async ({ page }) => {
-  await page.goto("/devgovgigs.near/widget/app?page=feed");
+  await page.goto("/devhub.near/widget/dh.feed");
 
   // Fill the search by content by to
   const searchInputSelector = 'input.form-control[type="search"]';

--- a/src/DevGov/Notification/Item/Left.jsx
+++ b/src/DevGov/Notification/Item/Left.jsx
@@ -19,9 +19,8 @@ return props.type ? (
     <a
       className="fw-bold text-muted"
       href={href({
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.post",
         params: {
-          page: "post",
           id: props.post,
         },
       })}

--- a/src/DevGov/Notification/Item/Right.jsx
+++ b/src/DevGov/Notification/Item/Right.jsx
@@ -7,9 +7,8 @@ return props.post === undefined ? (
     <a
       className="btn btn-outline-dark"
       href={href({
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.post",
         params: {
-          page: "post",
           id: props.post,
         },
       })}

--- a/src/devhub/components/island/connect.jsx
+++ b/src/devhub/components/island/connect.jsx
@@ -102,7 +102,7 @@ const Cards = communities.map((com) => {
   return {
     title: com.name,
     description: com.description,
-    href: "/${REPL_DEVHUB}/widget/app?page=community&handle=" + com.handle,
+    href: "/${REPL_DEVHUB}/widget/dh.community?handle=" + com.handle,
   };
 });
 
@@ -309,7 +309,7 @@ const Content = (
       ))}
     </MobileCards>
     <CTAContainer>
-      <CTA href="/${REPL_DEVHUB}/widget/app?page=communities">
+      <CTA href="/${REPL_DEVHUB}/widget/dh.communities">
         Explore all communities →
       </CTA>
     </CTAContainer>

--- a/src/devhub/components/island/hero.jsx
+++ b/src/devhub/components/island/hero.jsx
@@ -181,10 +181,7 @@ return (
         </Lead>
         <Link
           to={href({
-            widgetSrc: "${REPL_DEVHUB}/widget/app",
-            params: {
-              page: "about",
-            },
+            widgetSrc: "${REPL_DEVHUB}/widget/dh.about",
           })}
         >
           <CTA href="#">Read more →</CTA>
@@ -199,7 +196,7 @@ return (
       <Lead>Join a vibrant community of innovators shaping the open web.</Lead>
       <Link
         to={href({
-          widgetSrc: "${REPL_DEVHUB}/widget/app",
+          widgetSrc: "${REPL_DEVHUB}/widget/dh.about",
           params: {
             page: "about",
           },

--- a/src/devhub/components/island/participate.jsx
+++ b/src/devhub/components/island/participate.jsx
@@ -37,17 +37,17 @@ const Links = [
     links: [
       {
         title: "Ideate on DevHub",
-        href: "/devhub.near/widget/app?page=blog&id=2029",
+        href: "/devhub.near/widget/dh.blog?id=2029",
         count: 1,
       },
       {
         title: "Post a Proposal",
-        href: "/devhub.near/widget/app?page=blog&id=2035",
+        href: "/devhub.near/widget/dh.blog?id=2035",
         count: 2,
       },
       {
         title: "Host an Event",
-        href: "/devhub.near/widget/app?page=community&handle=hacks&tab=Wiki%202",
+        href: "/devhub.near/widget/dh.community?handle=hacks&tab=Wiki%202",
         count: 3,
       },
     ],
@@ -61,12 +61,12 @@ const Links = [
       },
       {
         title: "Join the Fellowship",
-        href: "/devhub.near/widget/app?page=community&handle=fellowship&tab=Wiki%201",
+        href: "/devhub.near/widget/dh.community?handle=fellowship&tab=Wiki%201",
         count: 5,
       },
       {
         title: "Join NEAR Campus",
-        href: "/devhub.near/widget/app?page=community&handle=near-campus",
+        href: "/devhub.near/widget/dh.community?handle=near-campus",
         count: 6,
       },
     ],

--- a/src/devhub/components/island/participate.jsx
+++ b/src/devhub/components/island/participate.jsx
@@ -183,8 +183,7 @@ const Content = (
 
     <Link
       to={href({
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
-        params: { page: "contribute" },
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.contribute",
       })}
       style={{ textDecoration: "none" }}
     >

--- a/src/devhub/components/island/support.jsx
+++ b/src/devhub/components/island/support.jsx
@@ -23,7 +23,7 @@ const Items = [
       </>
     ),
     cta: {
-      href: "/devhub.near/widget/app?page=community&handle=education&tab=Wiki%202",
+      href: "/devhub.near/widget/dh.community?handle=education&tab=Wiki%202",
       title: "Book a meeting ↗",
     },
   },
@@ -32,7 +32,7 @@ const Items = [
     description:
       "Explore funding opportunities from DevHub to fuel your vision",
     cta: {
-      href: "/devhub.near/widget/app?page=community&handle=developer-dao&tab=Funding",
+      href: "/devhub.near/widget/dh.community?handle=developer-dao&tab=Funding",
       title: "Learn more ↗",
     },
   },

--- a/src/devhub/components/molecule/NavbarDropdown.jsx
+++ b/src/devhub/components/molecule/NavbarDropdown.jsx
@@ -76,8 +76,7 @@ return (
         <Link
           style={{ textDecoration: "none" }}
           to={linkHref({
-            widgetSrc: "${REPL_DEVHUB}/widget/app",
-            params: { page: href },
+            widgetSrc: `${REPL_DEVHUB}/widget/dh.${href}`,
           })}
         >
           {title}
@@ -113,8 +112,7 @@ return (
                 <Link
                   style={{ textDecoration: "none" }}
                   to={linkHref({
-                    widgetSrc: "${REPL_DEVHUB}/widget/app",
-                    params: { page: link.href },
+                    widgetSrc: `${REPL_DEVHUB}/widget/dh.${link.href}`,
                   })}
                 >
                   {link.title}

--- a/src/devhub/components/organism/Navbar.jsx
+++ b/src/devhub/components/organism/Navbar.jsx
@@ -26,8 +26,7 @@ const Logo = () => {
     <Wrapper>
       <Link
         to={linkHref({
-          widgetSrc: "${REPL_DEVHUB}/widget/app",
-          params: { page: "home" },
+          widgetSrc: "${REPL_DEVHUB}/widget/dh.home",
         })}
       >
         <svg
@@ -68,8 +67,8 @@ const ProfileIcon = () => {
   return (
     <Link
       to={linkHref({
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
-        params: { page: "profile", accountId: context.accountId },
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.profile",
+        params: { accountId: context.accountId },
       })}
     >
       <Widget

--- a/src/devhub/components/organism/Navbar.jsx
+++ b/src/devhub/components/organism/Navbar.jsx
@@ -258,7 +258,7 @@ return (
               <MobileLink
                 key={`mobile-link-${idx}`}
                 className={link.href === props.page && "active"}
-                href={`/${REPL_DEVHUB}/widget/app?page=${link.href}`}
+                href={`/${REPL_DEVHUB}/widget/dh.${link.href}`}
               >
                 {link.title}
               </MobileLink>
@@ -278,7 +278,7 @@ return (
                   <MobileLink
                     key={`nested-link-${idx}`}
                     className={link.href === props.page && "active"}
-                    href={`/${REPL_DEVHUB}/widget/app?page=${it.href}`}
+                    href={`/${REPL_DEVHUB}/widget/dh.${it.href}`}
                   >
                     /{it.title}
                   </MobileLink>

--- a/src/devhub/entity/addon/blog/Viewer.jsx
+++ b/src/devhub/entity/addon/blog/Viewer.jsx
@@ -47,8 +47,8 @@ function BlogCard(postId) {
     <Link
       style={{ textDecoration: "none" }}
       to={href({
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
-        params: { page: "blog", id: postId },
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.blog",
+        params: { id: postId },
       })}
     >
       <CardContainer>

--- a/src/devhub/entity/addon/github/Viewer.jsx
+++ b/src/devhub/entity/addon/github/Viewer.jsx
@@ -12,8 +12,8 @@ return (
       communityHandle: handle, // rather than fetching again via the handle
       link: href({
         // do we need a link?
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
-        params: { page: "community", handle },
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.community",
+        params: { handle },
       }),
       permissions,
     }}

--- a/src/devhub/entity/addon/kanban/Viewer.jsx
+++ b/src/devhub/entity/addon/kanban/Viewer.jsx
@@ -13,8 +13,8 @@ const CommunityBoardPage = ({ handle, permissions }) => {
         communityHandle: handle, // rather than fetching again via the handle
         link: href({
           // do we need a link?
-          widgetSrc: "${REPL_DEVHUB}/widget/app",
-          params: { page: "community", handle },
+          widgetSrc: "${REPL_DEVHUB}/widget/dh.community",
+          params: { handle },
         }),
         permissions,
       }}

--- a/src/devhub/entity/community/Activity.jsx
+++ b/src/devhub/entity/community/Activity.jsx
@@ -53,9 +53,8 @@ return (
                   props={{
                     title: "Post",
                     href: href({
-                      widgetSrc: "${REPL_DEVHUB}/widget/app",
+                      widgetSrc: "${REPL_DEVHUB}/widget/dh.create",
                       params: {
-                        page: "create",
                         labels: [communityData.tag],
                       },
                     }),

--- a/src/devhub/entity/community/Card.jsx
+++ b/src/devhub/entity/community/Card.jsx
@@ -50,8 +50,8 @@ const Card = styled.div`
 const CommunityCard = ({ metadata }) => {
   const { handle, logo_url, name, description } = metadata;
   const link = href({
-    widgetSrc: "${REPL_DEVHUB}/widget/app",
-    params: { page: "community", handle: handle },
+    widgetSrc: "${REPL_DEVHUB}/widget/dh.community",
+    params: { handle: handle },
   });
 
   return (

--- a/src/devhub/entity/community/Sidebar.jsx
+++ b/src/devhub/entity/community/Sidebar.jsx
@@ -18,8 +18,8 @@ const CommunitySummary = () => {
       <small class="text-muted mb-3">
         <Link
           to={href({
-            widgetSrc: "${REPL_DEVHUB}/widget/app",
-            params: { page: "feed", tag: community.tag },
+            widgetSrc: "${REPL_DEVHUB}/widget/dh.feed",
+            params: { tag: community.tag },
           })}
         >
           <Widget

--- a/src/devhub/entity/community/Spawner.jsx
+++ b/src/devhub/entity/community/Spawner.jsx
@@ -81,7 +81,6 @@ return (
   <Widget
     src="${REPL_DEVHUB}/widget/devhub.components.organism.Configurator"
     props={{
-      heading: "Community information",
       externalState: CommunityInputsDefaults,
       fullWidth: true,
       isActive: true,

--- a/src/devhub/entity/post/List.jsx
+++ b/src/devhub/entity/post/List.jsx
@@ -406,8 +406,7 @@ return (
           }}
           className="fw-bold"
           to={href({
-            widgetSrc: "${REPL_DEVHUB}/widget/app",
-            params: { page: "feed" },
+            widgetSrc: "${REPL_DEVHUB}/widget/dh.feed",
           })}
         >
           feed

--- a/src/devhub/entity/post/Post.jsx
+++ b/src/devhub/entity/post/Post.jsx
@@ -159,8 +159,8 @@ const shareButton = props.isPreview ? (
   <Link
     class="card-link text-dark"
     to={href({
-      widgetSrc: "${REPL_DEVHUB}/widget/app",
-      params: { page: "post", id: postId },
+      widgetSrc: "${REPL_DEVHUB}/widget/dh.post",
+      params: { id: postId },
     })}
     role="button"
     target="_blank"
@@ -433,8 +433,8 @@ const buttonsFooter = props.isPreview ? null : (
         ) : (
           <Link
             to={href({
-              widgetSrc: "${REPL_DEVHUB}/widget/app",
-              params: { page: "post", id: parentId },
+              widgetSrc: "${REPL_DEVHUB}/widget/dh.post",
+              params: { id: parentId },
             })}
           >
             <ButtonWithHover
@@ -645,8 +645,8 @@ const tags = post.snapshot.labels ? (
       <div className="d-flex align-items-center my-3 me-3">
         <Link
           to={href({
-            widgetSrc: "${REPL_DEVHUB}/widget/app",
-            params: { page: "feed", tag: tag },
+            widgetSrc: "${REPL_DEVHUB}/widget/dh.feed",
+            params: { tag: tag },
           })}
         >
           <div
@@ -826,9 +826,8 @@ const timestampElement = (_snapshot) => {
     <Link
       class="text-muted"
       href={href({
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.post",
         params: {
-          page: "post",
           id: postId,
           timestamp: _snapshot.timestamp,
           compareTimestamp: null,

--- a/src/devhub/feature/post-search/panel.jsx
+++ b/src/devhub/feature/post-search/panel.jsx
@@ -87,8 +87,7 @@ return (
                       style={{ borderRadius: "5px" }}
                       class="dropdown-item link-underline link-underline-opacity-0"
                       href={href({
-                        widgetSrc: "${REPL_DEVHUB}/widget/app",
-                        params: { page: "feed" },
+                        widgetSrc: "${REPL_DEVHUB}/widget/dh.feed",
                       })}
                     >
                       Latest
@@ -99,8 +98,8 @@ return (
                       style={{ borderRadius: "5px" }}
                       class="dropdown-item link-underline link-underline-opacity-0"
                       href={href({
-                        widgetSrc: "${REPL_DEVHUB}/widget/app",
-                        params: { page: "feed", recency: "all" },
+                        widgetSrc: "${REPL_DEVHUB}/widget/page.feed",
+                        params: { recency: "all" },
                       })}
                     >
                       All replies

--- a/src/devhub/page/community/configuration.jsx
+++ b/src/devhub/page/community/configuration.jsx
@@ -51,7 +51,7 @@ return (
           onSubmit: sectionSubmit,
           data: communityData,
           hasConfigurePermissions,
-          link: `/${REPL_DEVHUB}/widget/app?page=community&handle=${handle}`,
+          link: `/${REPL_DEVHUB}/widget/dh.community?handle=${handle}`,
         }}
       />
     </Tile>

--- a/src/devhub/page/community/index.jsx
+++ b/src/devhub/page/community/index.jsx
@@ -213,7 +213,7 @@ return (
       <div className="d-flex align-items-end gap-3 ms-auto mb-md-5 me-4">
         {permissions.can_configure && (
           <Link
-            to={`/${REPL_DEVHUB}/widget/app?page=community.configuration&handle=${community.handle}`}
+            to={`/${REPL_DEVHUB}/widget/dh.community.configuration?handle=${community.handle}`}
           >
             <Widget
               src={"${REPL_DEVHUB}/widget/devhub.components.molecule.Button"}

--- a/src/devhub/page/community/index.jsx
+++ b/src/devhub/page/community/index.jsx
@@ -79,8 +79,8 @@ const onShareClick = () =>
     .writeText(
       href({
         gateway: "near.social",
-        widgetSrc: "${REPL_DEVHUB}/widget/app",
-        params: { page: "community", handle: community.handle },
+        widgetSrc: "${REPL_DEVHUB}/widget/dh.community",
+        params: { handle: community.handle },
       })
     )
     .then(setLinkCopied(true));
@@ -270,9 +270,8 @@ return (
               <li className="nav-item" key={title}>
                 <Link
                   to={href({
-                    widgetSrc: "${REPL_DEVHUB}/widget/app",
+                    widgetSrc: "${REPL_DEVHUB}/widget/dh.community",
                     params: {
-                      page: "community",
                       handle: community.handle,
                       tab: title,
                     },
@@ -299,8 +298,8 @@ return (
               <span>Required tags:</span>
               <Link
                 to={href({
-                  widgetSrc: "${REPL_DEVHUB}/widget/app",
-                  params: { page: "feed", tag: community.tag },
+                  widgetSrc: "${REPL_DEVHUB}/widget/dh.feed",
+                  params: { tag: community.tag },
                 })}
               >
                 <Widget
@@ -320,9 +319,8 @@ return (
               props={{
                 title: "Post",
                 href: href({
-                  widgetSrc: "${REPL_DEVHUB}/widget/app",
+                  widgetSrc: "${REPL_DEVHUB}/widget/dh.create",
                   params: {
-                    page: "create",
                     labels: [community.tag],
                   },
                 }),

--- a/src/devhub/page/contribute.jsx
+++ b/src/devhub/page/contribute.jsx
@@ -52,21 +52,21 @@ const actions = [
     description:
       "The first step in any NEAR ecosystem project is ideation. It is crucial to have a way to find people to share and explore ideas with, partly because it can save a lot of time based on prior discussions. But also because it can you gauge support from a diversity of stakeholders.",
     ctaAction: "Learn More →",
-    ctaLink: "/devhub.near/widget/app?page=blog&id=2029",
+    ctaLink: "/devhub.near/widget/dh.blog?id=2029",
   },
   {
     title: "Post a Proposal",
     description:
       "If you have already nurtured and refined your idea, you're ready to draft and post your funding proposal.This guide is here to help you craft a compelling, convincing, and concise proposal that will capture the interest of potential funders.",
     ctaAction: "Learn More →",
-    ctaLink: "/devhub.near/widget/app?page=blog&id=2035",
+    ctaLink: "/devhub.near/widget/dh.blog?id=2035",
   },
   {
     title: "Host an Event",
     description:
       "We are always on the lookout for events that align with our mission and provide value to the NEAR ecosystem. If you are organizing such an event, we would love to hear from you! Below is a guide on how to submit a sponsorship proposal to us.",
     ctaAction: "Learn More →",
-    ctaLink: "/devhub.near/widget/app?page=community&handle=hacks&tab=Wiki%202",
+    ctaLink: "/devhub.near/widget/dh.community?handle=hacks&tab=Wiki%202",
   },
   {
     title: "Improve NEAR Docs",
@@ -80,15 +80,14 @@ const actions = [
     description:
       "As the NEAR ecosystem grows rapidly, there is an increasing need to improve developer productivity. The DevDAO NEAR Platform Fellowship Program aims to solve this issue by providing guidance to new contributors from experienced developers.",
     ctaAction: "Learn More →",
-    ctaLink:
-      "/devhub.near/widget/app?page=community&handle=fellowship&tab=Wiki 1",
+    ctaLink: "/devhub.near/widget/dh.community?handle=fellowship&tab=Wiki 1",
   },
   {
     title: "Join NEAR Campus",
     description:
       "DevHub’s NEAR Campus supports existing student clubs, researchers, and faculties in blockchain technologies, enhancing both curricular and extracurricular activities. We aim to merge blockchain education with mainstream academics.",
     ctaAction: "Learn More →",
-    ctaLink: "/devhub.near/widget/app?page=community&handle=near-campus",
+    ctaLink: "/devhub.near/widget/dh.community?handle=near-campus",
   },
   {
     title: "Dive into Hackbox",

--- a/src/devhub/page/create.jsx
+++ b/src/devhub/page/create.jsx
@@ -96,6 +96,11 @@ const labels = labelStrings.map((s) => {
   return { name: s };
 });
 
+// If the post is created from the community page the label is set by default.
+State.update({
+  labels,
+});
+
 if (state.waitForDraftStateRestore) {
   const draftstatestring = Storage.privateGet(DRAFT_STATE_STORAGE_KEY);
   if (draftstatestring != null) {

--- a/src/devhub/page/create.jsx
+++ b/src/devhub/page/create.jsx
@@ -472,8 +472,7 @@ return (
               }}
               className="fw-bold"
               to={href({
-                widgetSrc: "${REPL_DEVHUB}/widget/app",
-                params: { page: "feed" },
+                widgetSrc: "${REPL_DEVHUB}/widget/dh.feed",
               })}
             >
               DevHub
@@ -493,8 +492,7 @@ return (
             }}
             className="fw-bold"
             to={href({
-              widgetSrc: "${REPL_DEVHUB}/widget/app",
-              params: { page: "feed" },
+              widgetSrc: "${REPL_DEVHUB}/widget/dh.feed",
             })}
           >
             feed

--- a/src/devhub/page/create.jsx
+++ b/src/devhub/page/create.jsx
@@ -270,6 +270,7 @@ const setLabels = (labels) => {
     State.update({ labels, labelStrings });
   }
 };
+
 const existingLabelStrings =
   Near.view("${REPL_DEVHUB_CONTRACT}", "get_all_allowed_labels", {
     editor: context.accountId,

--- a/src/devhub/page/feed.jsx
+++ b/src/devhub/page/feed.jsx
@@ -57,8 +57,7 @@ const FeedPage = ({ recency, tag }) => {
               props={{
                 title: "Post",
                 href: href({
-                  widgetSrc: "${REPL_DEVHUB}/widget/app",
-                  params: { page: "create" },
+                  widgetSrc: "${REPL_DEVHUB}/widget/dh.create",
                 }),
               }}
             />

--- a/src/devhub/page/post.jsx
+++ b/src/devhub/page/post.jsx
@@ -14,9 +14,7 @@ return (
   <Container>
     <Widget
       src={"${REPL_DEVHUB}/widget/devhub.entity.post.Post"}
-      props={{
-        id,
-      }}
+      props={props}
     />
   </Container>
 );

--- a/src/dh/about.jsx
+++ b/src/dh/about.jsx
@@ -1,0 +1,3 @@
+return (
+  <Widget src="${REPL_DEVHUB}/widget/app" props={{ page: "about", ...props }} />
+);

--- a/src/dh/addon.jsx
+++ b/src/dh/addon.jsx
@@ -1,0 +1,3 @@
+return (
+  <Widget src="${REPL_DEVHUB}/widget/app" props={{ page: "addon", ...props }} />
+);

--- a/src/dh/admin.jsx
+++ b/src/dh/admin.jsx
@@ -1,0 +1,3 @@
+return (
+  <Widget src="${REPL_DEVHUB}/widget/app" props={{ page: "admin", ...props }} />
+);

--- a/src/dh/blog.jsx
+++ b/src/dh/blog.jsx
@@ -1,0 +1,3 @@
+return (
+  <Widget src="${REPL_DEVHUB}/widget/app" props={{ page: "blog", ...props }} />
+);

--- a/src/dh/communities.jsx
+++ b/src/dh/communities.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_DEVHUB}/widget/app"
+    props={{ page: "communities", ...props }}
+  />
+);

--- a/src/dh/community.jsx
+++ b/src/dh/community.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_DEVHUB}/widget/app"
+    props={{ page: "community", ...props }}
+  />
+);

--- a/src/dh/community/configuration.jsx
+++ b/src/dh/community/configuration.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_DEVHUB}/widget/app"
+    props={{ page: "community.configuration", ...props }}
+  />
+);

--- a/src/dh/community/index.jsx
+++ b/src/dh/community/index.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_DEVHUB}/widget/app"
+    props={{ page: "community.index", ...props }}
+  />
+);

--- a/src/dh/contribute.jsx
+++ b/src/dh/contribute.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_DEVHUB}/widget/app"
+    props={{ page: "contribute", ...props }}
+  />
+);

--- a/src/dh/create.jsx
+++ b/src/dh/create.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_DEVHUB}/widget/app"
+    props={{ page: "create", ...props }}
+  />
+);

--- a/src/dh/feed.jsx
+++ b/src/dh/feed.jsx
@@ -1,0 +1,3 @@
+return (
+  <Widget src="${REPL_DEVHUB}/widget/app" props={{ page: "feed", ...props }} />
+);

--- a/src/dh/home.jsx
+++ b/src/dh/home.jsx
@@ -1,0 +1,3 @@
+return (
+  <Widget src="${REPL_DEVHUB}/widget/app" props={{ page: "home", ...props }} />
+);

--- a/src/dh/post.jsx
+++ b/src/dh/post.jsx
@@ -1,0 +1,3 @@
+return (
+  <Widget src="${REPL_DEVHUB}/widget/app" props={{ page: "post", ...props }} />
+);

--- a/src/dh/profile.jsx
+++ b/src/dh/profile.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_DEVHUB}/widget/app"
+    props={{ page: "profile", ...props }}
+  />
+);


### PR DESCRIPTION
_Resolves #350_

All links now direct to `devhub.near/widget/dh.${pagename}`.

I implented it to be backwards compatible since some users might have bookmarks with the `app?page=${pagename}` structure in the url.

[preview](https://near.org/thomasguntenaar.near/widget/dh.feed)

