### PR TITLE
Points tests to devhub.near rather than devgovgigs.near

### DIFF
--- a/playwright-tests/tests/addons.spec.js
+++ b/playwright-tests/tests/addons.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require("@playwright/test");
+const { test } = require("@playwright/test");
 
 test.describe("Wallet is connected", () => {
   test.use({
@@ -7,7 +7,7 @@ test.describe("Wallet is connected", () => {
 
   test.describe("AddonsConfigurator", () => {
     const baseUrl =
-      "/devgovgigs.near/widget/app?page=community.configuration&handle=devhub-test";
+      "/devhub.near/widget/app?page=community.configuration&handle=devhub-test";
     // const dropdownSelector =
     //   'input[data-component="near/widget/DIG.InputSelect"]';
     // const addButtonSelector = "button.btn-success:has(i.bi.bi-plus)";

--- a/playwright-tests/tests/blog.spec.js
+++ b/playwright-tests/tests/blog.spec.js
@@ -1,11 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { waitForSelectorToBeVisible } from "../testUtils";
 
 test("should load blogs in the sidebar for a given handle", async ({
   page,
 }) => {
   await page.goto(
-    "/devgovgigs.near/widget/devhub.entity.addon.blog.Configurator?handle=devhub-test"
+    "/devhub.near/widget/devhub.entity.addon.blog.Configurator?handle=devhub-test"
   );
 
   await page.waitForSelector(`[id^="edit-blog-selector-"]`);
@@ -19,7 +18,7 @@ test("should prepopulate the form when a blog is selected from the left", async 
   page,
 }) => {
   await page.goto(
-    "/devgovgigs.near/widget/devhub.entity.addon.blog.Configurator?handle=devhub-test"
+    "/devhub.near/widget/devhub.entity.addon.blog.Configurator?handle=devhub-test"
   );
 
   await page.waitForSelector(`[id^="edit-blog-selector-"]`);
@@ -57,9 +56,7 @@ test("should prepopulate the form when a blog is selected from the left", async 
 });
 
 test("should have an empty form if select new blog", async ({ page }) => {
-  await page.goto(
-    "/devgovgigs.near/widget/devhub.entity.addon.blog.Configurator"
-  );
+  await page.goto("/devhub.near/widget/devhub.entity.addon.blog.Configurator");
 
   const newBlogSelector = `[id^="create-new-blog"]`;
   await page.waitForSelector(newBlogSelector, {
@@ -96,7 +93,7 @@ test("should load a blog page and its blogs for a given community handle", async
   page,
 }) => {
   await page.goto(
-    "/devgovgigs.near/widget/devhub.entity.addon.blog.Viewer?handle=devhub-test"
+    "/devhub.near/widget/devhub.entity.addon.blog.Viewer?handle=devhub-test"
   );
 
   const blogCardSelector = '[id^="blog-card-"]';

--- a/playwright-tests/tests/bosloaderenvironment.spec.js
+++ b/playwright-tests/tests/bosloaderenvironment.spec.js
@@ -14,7 +14,7 @@ test("should find bos loader configuration in localstorage", async ({
 });
 
 test("should not get bos loader fetch error", async ({ page }) => {
-  await page.goto("/devgovgigs.near/widget/gigs-board.pages.Feed");
+  await page.goto("/devhub.near/widget/app?page=feed");
   const bodyText = await page.textContent("body");
   expect(bodyText).not.toContain("BOS Loader fetch error");
 });

--- a/playwright-tests/tests/communities.spec.js
+++ b/playwright-tests/tests/communities.spec.js
@@ -37,7 +37,7 @@ test.describe("Wallet is connected", () => {
       'button:has-text("Create Community")'
     );
 
-    await waitForSelectorToBeVisible(page, 'button:has-text("Laucnh")');
+    await waitForSelectorToBeVisible(page, 'button:has-text("Launch")');
 
     // missing title
     await expectInputValidation(

--- a/playwright-tests/tests/communities.spec.js
+++ b/playwright-tests/tests/communities.spec.js
@@ -1,6 +1,6 @@
 import {
-  setInputAndAssert,
   clickWhenSelectorIsVisible,
+  setInputAndAssert,
   waitForSelectorToBeVisible,
 } from "../testUtils";
 
@@ -14,7 +14,7 @@ test.describe("Wallet is connected", () => {
   test("should show spawner when user clicks create community", async ({
     page,
   }) => {
-    await page.goto("/devgovgigs.near/widget/app?page=communities");
+    await page.goto("/devhub.near/widget/app?page=communities");
 
     const createCommunityButtonSelector = 'button:has-text("Create Community")';
 
@@ -23,24 +23,21 @@ test.describe("Wallet is connected", () => {
     });
     await page.click(createCommunityButtonSelector);
 
-    const communitySpawnerSelector = 'div:has-text("Community information")';
+    const communitySpawnerSelector = 'button:has-text("Launch")';
     await page.waitForSelector(communitySpawnerSelector, { state: "visible" });
   });
 
   test("should validate input when user is creating a new community", async ({
     page,
   }) => {
-    await page.goto("/devgovgigs.near/widget/app?page=communities");
+    await page.goto("/devhub.near/widget/app?page=communities");
 
     await clickWhenSelectorIsVisible(
       page,
       'button:has-text("Create Community")'
     );
 
-    await waitForSelectorToBeVisible(
-      page,
-      'div:has-text("Community information")'
-    );
+    await waitForSelectorToBeVisible(page, 'button:has-text("Laucnh")');
 
     // missing title
     await expectInputValidation(
@@ -116,7 +113,7 @@ test.describe("Wallet is not connected", () => {
   });
 
   test("spawner and button should not be visible", async ({ page }) => {
-    await page.goto("/devgovgigs.near/widget/app?page=communities");
+    await page.goto("/devhub.near/widget/app?page=communities");
 
     const createCommunityButtonSelector = 'button:has-text("Create Community")';
 

--- a/playwright-tests/tests/community.spec.js
+++ b/playwright-tests/tests/community.spec.js
@@ -20,7 +20,7 @@ test("should load a community page if handle exists", async ({ page }) => {
 
 test("should load an error page if handle does not exist", async ({ page }) => {
   await page.goto(
-    "/devgovgigs.near/widget/app?page=community&handle=devhub-faketest"
+    "/devhub.near/widget/app?page=community&handle=devhub-faketest"
   );
 
   // Using the <Link> that wraps the card to identify a community
@@ -89,7 +89,7 @@ test.describe("Wallet is not connected", () => {
     page,
   }) => {
     await page.goto(
-      "/devgovgigs.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=devhub-test"
     );
 
     const createCommunityButtonSelector = 'button:has-text("Post")';

--- a/playwright-tests/tests/create.spec.js
+++ b/playwright-tests/tests/create.spec.js
@@ -7,195 +7,202 @@ test.describe("Wallet is not connected", () => {
     storageState: "playwright-tests/storage-states/wallet-not-connected.json",
   });
 
-  test("should not be able to create if not logged in", async ({ page }) => {
+  test("should be able to submit a solution with USDC as currency", async ({
+    page,
+  }) => {
     await page.goto("/devhub.near/widget/app?page=create");
 
-    const createPostButton = 'button[data-testid="submit-create-post"]';
+    test("should not be able to create if not logged in", async ({ page }) => {
+      await page.goto("/devhub.near/widget/app?page=create");
 
-    await page.waitForSelector(createPostButton, {
-      state: "detached",
+      const createPostButton = 'button[data-testid="submit-create-post"]';
+
+      await page.waitForSelector(createPostButton, {
+        state: "detached",
+      });
+
+      const isCreatePostButtonVisible = await page.isVisible(createPostButton);
+
+      expect(isCreatePostButtonVisible).toBeFalsy();
+    });
+  });
+
+  test.describe("Wallet is connected", () => {
+    // sign in to wallet
+    test.use({
+      storageState: "playwright-tests/storage-states/wallet-connected.json",
     });
 
-    const isCreatePostButtonVisible = await page.isVisible(createPostButton);
-
-    expect(isCreatePostButtonVisible).toBeFalsy();
-  });
-});
-
-test.describe("Wallet is connected", () => {
-  // sign in to wallet
-  test.use({
-    storageState: "playwright-tests/storage-states/wallet-connected.json",
-  });
-
-  test("should be able to submit a solution (funding request) with USDC as currency", async ({
-    page,
-  }) => {
-    await page.goto("/devhub.near/widget/app?page=create");
-
-    await page.click('button:has-text("Solution")');
-
-    await setInputAndAssert(
+    test("should be able to submit a solution (funding request) with USDC as currency", async ({
       page,
-      'input[data-testid="name-editor"]',
-      "The test title"
-    );
+    }) => {
+      await page.goto("/devhub.near/widget/app?page=create");
 
-    const descriptionInput = page
-      .frameLocator("iframe")
-      .locator(".CodeMirror textarea");
-    await descriptionInput.focus();
-    await descriptionInput.fill("Developer contributor report by somebody");
+      await page.click('button:has-text("Solution")');
 
-    const tagsInput = page.locator(".rbt-input-multi");
-    await tagsInput.focus();
-    await tagsInput.pressSequentially("paid-cont", { delay: 100 });
-    await tagsInput.press("Tab");
-    await tagsInput.pressSequentially("developer-da", { delay: 100 });
-    await tagsInput.press("Tab");
+      await setInputAndAssert(
+        page,
+        'input[data-testid="name-editor"]',
+        "The test title"
+      );
 
-    await page.click('label:has-text("Yes") button');
-    await selectAndAssert(page, 'div:has-text("Currency") select', "USDT");
-    await setInputAndAssert(
-      page,
-      'input[data-testid="requested-amount-editor"]',
-      "300"
-    );
-    await page.click('button:has-text("Submit")');
-    await expect(page.locator("div.modal-body code")).toHaveText(
-      JSON.stringify(
-        {
-          parent_id: null,
-          labels: ["paid-contributor", "developer-dao"],
-          body: {
-            name: "The test title",
-            description:
-              "###### Requested amount: 300 USDT\n###### Requested sponsor: @neardevdao.near\nDeveloper contributor report by somebody",
-            solution_version: "V1",
-            post_type: "Solution",
+      const descriptionInput = page
+        .frameLocator("iframe")
+        .locator(".CodeMirror textarea");
+      await descriptionInput.focus();
+      await descriptionInput.fill("Developer contributor report by somebody");
+
+      const tagsInput = page.locator(".rbt-input-multi");
+      await tagsInput.focus();
+      await tagsInput.pressSequentially("paid-cont", { delay: 100 });
+      await tagsInput.press("Tab");
+      await tagsInput.pressSequentially("developer-da", { delay: 100 });
+      await tagsInput.press("Tab");
+
+      await page.click('label:has-text("Yes") button');
+      await selectAndAssert(page, 'div:has-text("Currency") select', "USDT");
+      await setInputAndAssert(
+        page,
+        'input[data-testid="requested-amount-editor"]',
+        "300"
+      );
+      await page.click('button:has-text("Submit")');
+      await expect(page.locator("div.modal-body code")).toHaveText(
+        JSON.stringify(
+          {
+            parent_id: null,
+            labels: ["paid-contributor", "developer-dao"],
+            body: {
+              name: "The test title",
+              description:
+                "###### Requested amount: 300 USDT\n###### Requested sponsor: @neardevdao.near\nDeveloper contributor report by somebody",
+              solution_version: "V1",
+              post_type: "Solution",
+            },
           },
-        },
-        null,
-        2
-      )
-    );
+          null,
+          2
+        )
+      );
+    });
+
+    test("should init create post with single label from params", async ({
+      page,
+    }) => {
+      await page.goto("/devhub.near/widget/app?page=create&labels=devhub-test");
+
+      const selector = ".rbt-input-multi";
+      const typeAheadElement = await page.waitForSelector(selector);
+
+      const tokenWithValue = await typeAheadElement.$(
+        '.rbt-token:has-text("devhub-test")'
+      );
+      expect(tokenWithValue).toBeTruthy();
+    });
+
+    test("should init create post with multi label from params", async ({
+      page,
+    }) => {
+      await page.goto(
+        "/devhub.near/widget/app?page=create&labels=devhub-test,security"
+      );
+
+      const selector = ".rbt-input-multi";
+      const typeAheadElement = await page.waitForSelector(selector);
+
+      const devhubTestToken = await typeAheadElement.$(
+        '.rbt-token:has-text("devhub-test")'
+      );
+      expect(devhubTestToken).toBeTruthy();
+      const securityToken = await typeAheadElement.$(
+        '.rbt-token:has-text("security")'
+      );
+      expect(securityToken).toBeTruthy();
+    });
+
+    test("should allow user to select multiple labels", async ({ page }) => {
+      await page.goto("/devhub.near/widget/app?page=create");
+      const selector = ".rbt-input-main";
+      await page.waitForSelector(selector);
+      await page.fill(selector, "devhub-test");
+
+      await page.getByLabel("devhub-test").click();
+
+      await page.fill(selector, "security");
+      await page.getByLabel("security").click();
+
+      const typeAheadElement = await page.waitForSelector(".rbt-input-multi");
+      const devhubToken = await typeAheadElement.$(
+        `.rbt-token:has-text("devhub-test")`
+      );
+      expect(devhubToken).toBeTruthy();
+
+      const securityToken = await typeAheadElement.$(
+        `.rbt-token:has-text("security")`
+      );
+      expect(securityToken).toBeTruthy();
+    });
+
+    test("should not allow user to use the blog label", async ({ page }) => {
+      await page.goto("/devhub.near/widget/app?page=create");
+
+      const selector = ".rbt-input-main";
+      await page.waitForSelector(selector);
+      await page.fill(selector, "blog");
+      const labelSelector = `:is(label:has-text("blog"))`;
+      await page.waitForSelector(labelSelector, { state: "detached" });
+    });
+
+    test("should not allow user to use a protected label", async ({ page }) => {
+      await page.goto("/devhub.near/widget/app?page=create");
+
+      const selector = ".rbt-input-main";
+      await page.waitForSelector(selector);
+      await page.fill(selector, "funding-requested");
+      const labelSelector = `:is(label:has-text("funding-requested"))`;
+      await page.waitForSelector(labelSelector, { state: "detached" });
+
+      await page.waitForSelector(".alert", { state: "visible" });
+    });
+
+    test("should allow the user to create new labels", async ({ page }) => {
+      await page.goto("/devhub.near/widget/app?page=create");
+
+      const selector = ".rbt-input-main";
+      await page.waitForSelector(selector);
+      await page.fill(selector, "random-crazy-label-lol");
+      const labelSelector = `:is(mark:has-text("random-crazy-label-lol"))`;
+      const element = await page.waitForSelector(labelSelector);
+      await element.click();
+
+      const typeAheadElement = await page.waitForSelector(".rbt-input-multi");
+      const newToken = await typeAheadElement.$(
+        `.rbt-token:has-text("random-crazy-label-lol")`
+      );
+      expect(newToken).toBeTruthy();
+    });
   });
 
-  test("should init create post with single label from params", async ({
-    page,
-  }) => {
-    await page.goto("/devhub.near/widget/app?page=create&labels=devhub-test");
+  test.describe("Admin is connected", () => {
+    // sign in to wallet
+    test.use({
+      storageState:
+        "playwright-tests/storage-states/wallet-connected-admin.json",
+    });
 
-    const selector = ".rbt-input-multi";
-    const typeAheadElement = await page.waitForSelector(selector);
+    test("should allow admin to use a protected label", async ({ page }) => {
+      await page.goto("/devhub.near/widget/app?page=create");
 
-    const tokenWithValue = await typeAheadElement.$(
-      '.rbt-token:has-text("devhub-test")'
-    );
-    expect(tokenWithValue).toBeTruthy();
-  });
+      const selector = ".rbt-input-main";
+      await page.waitForSelector(selector);
+      await page.fill(selector, "funding-requested");
+      await page.getByLabel("funding-requested").click();
 
-  test("should init create post with multi label from params", async ({
-    page,
-  }) => {
-    await page.goto(
-      "/devhub.near/widget/app?page=create&labels=devhub-test,security"
-    );
-
-    const selector = ".rbt-input-multi";
-    const typeAheadElement = await page.waitForSelector(selector);
-
-    const devhubTestToken = await typeAheadElement.$(
-      '.rbt-token:has-text("devhub-test")'
-    );
-    expect(devhubTestToken).toBeTruthy();
-    const securityToken = await typeAheadElement.$(
-      '.rbt-token:has-text("security")'
-    );
-    expect(securityToken).toBeTruthy();
-  });
-
-  test("should allow user to select multiple labels", async ({ page }) => {
-    await page.goto("/devhub.near/widget/app?page=create");
-    const selector = ".rbt-input-main";
-    await page.waitForSelector(selector);
-    await page.fill(selector, "devhub-test");
-
-    await page.getByLabel("devhub-test").click();
-
-    await page.fill(selector, "security");
-    await page.getByLabel("security").click();
-
-    const typeAheadElement = await page.waitForSelector(".rbt-input-multi");
-    const devhubToken = await typeAheadElement.$(
-      `.rbt-token:has-text("devhub-test")`
-    );
-    expect(devhubToken).toBeTruthy();
-
-    const securityToken = await typeAheadElement.$(
-      `.rbt-token:has-text("security")`
-    );
-    expect(securityToken).toBeTruthy();
-  });
-
-  test("should not allow user to use the blog label", async ({ page }) => {
-    await page.goto("/devhub.near/widget/app?page=create");
-
-    const selector = ".rbt-input-main";
-    await page.waitForSelector(selector);
-    await page.fill(selector, "blog");
-    const labelSelector = `:is(label:has-text("blog"))`;
-    await page.waitForSelector(labelSelector, { state: "detached" });
-  });
-
-  test("should not allow user to use a protected label", async ({ page }) => {
-    await page.goto("/devhub.near/widget/app?page=create");
-
-    const selector = ".rbt-input-main";
-    await page.waitForSelector(selector);
-    await page.fill(selector, "funding-requested");
-    const labelSelector = `:is(label:has-text("funding-requested"))`;
-    await page.waitForSelector(labelSelector, { state: "detached" });
-
-    await page.waitForSelector(".alert", { state: "visible" });
-  });
-
-  test("should allow the user to create new labels", async ({ page }) => {
-    await page.goto("/devhub.near/widget/app?page=create");
-
-    const selector = ".rbt-input-main";
-    await page.waitForSelector(selector);
-    await page.fill(selector, "random-crazy-label-lol");
-    const labelSelector = `:is(mark:has-text("random-crazy-label-lol"))`;
-    const element = await page.waitForSelector(labelSelector);
-    await element.click();
-
-    const typeAheadElement = await page.waitForSelector(".rbt-input-multi");
-    const newToken = await typeAheadElement.$(
-      `.rbt-token:has-text("random-crazy-label-lol")`
-    );
-    expect(newToken).toBeTruthy();
-  });
-});
-
-test.describe("Admin is connected", () => {
-  // sign in to wallet
-  test.use({
-    storageState: "playwright-tests/storage-states/wallet-connected-admin.json",
-  });
-
-  test("should allow admin to use a protected label", async ({ page }) => {
-    await page.goto("/devhub.near/widget/app?page=create");
-
-    const selector = ".rbt-input-main";
-    await page.waitForSelector(selector);
-    await page.fill(selector, "funding-requested");
-    await page.getByLabel("funding-requested").click();
-
-    const typeAheadElement = await page.waitForSelector(".rbt-input-multi");
-    const protectedToken = await typeAheadElement.$(
-      `.rbt-token:has-text("funding-requested")`
-    );
-    expect(protectedToken).toBeTruthy();
+      const typeAheadElement = await page.waitForSelector(".rbt-input-multi");
+      const protectedToken = await typeAheadElement.$(
+        `.rbt-token:has-text("funding-requested")`
+      );
+      expect(protectedToken).toBeTruthy();
+    });
   });
 });

--- a/playwright-tests/tests/feed.spec.js
+++ b/playwright-tests/tests/feed.spec.js
@@ -1,31 +1,7 @@
 import { test } from "@playwright/test";
 
-// LEGACY
-test("LEGACY: should show post history for posts in the feed", async ({
-  page,
-}) => {
-  await page.goto("/devgovgigs.near/widget/gigs-board.pages.Feed");
-
-  const firstPostHistoryButtonSelector = 'a.card-link[title="Post History"]';
-  // Wait for the first post history button to be visible
-  await page.waitForSelector(firstPostHistoryButtonSelector, {
-    state: "visible",
-  });
-
-  // Click on the first post history button
-  await page.click(firstPostHistoryButtonSelector);
-
-  // Wait for the next sibling element to be visible
-  const siblingSelector = `${firstPostHistoryButtonSelector} + *`;
-  await page.waitForSelector(siblingSelector, { state: "visible" });
-
-  // Check that inside that sibling element there's an element with the class: bi-file-earmark-diff
-  const desiredChildSelector = `${siblingSelector} .bi-file-earmark-diff`;
-  await page.waitForSelector(desiredChildSelector, { state: "visible" });
-});
-
 test("should show post history for posts in the feed", async ({ page }) => {
-  await page.goto("/devgovgigs.near/widget/app?page=feed");
+  await page.goto("/devhub.near/widget/app?page=feed");
 
   const firstPostHistoryButtonSelector = 'a.card-link[title="Post History"]';
   // Wait for the first post history button to be visible

--- a/playwright-tests/tests/search.spec.js
+++ b/playwright-tests/tests/search.spec.js
@@ -1,7 +1,7 @@
 import { test } from "@playwright/test";
 
 test("should show post history for posts in the feed", async ({ page }) => {
-  await page.goto("/devgovgigs.near/widget/app?page=feed");
+  await page.goto("/devhub.near/widget/app?page=feed");
 
   // Fill the search by content by to
   const searchInputSelector = 'input.form-control[type="search"]';


### PR DESCRIPTION
_Resolves #594_

**Blocked** 
The blog tests are configured with the addon deployed to [devgovgigs.near](https://near.org/devgovgigs.near/widget/devhub.entity.addon.blog.Configurator?handle=devhub-test)

They break when configured with the addon deployed to [devhub.near](https://near.org/devhub.near/widget/devhub.entity.addon.blog.Configurator?handle=devhub-test), as the blog selector does not show up. 