### PR TITLE
Test/critical regression

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": []
+    }
+  },
+  "postCreateCommand": ".devcontainer/post-create.sh"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+npm install
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mpeterdev/bos-loader/releases/download/v0.7.1/bos-loader-v0.7.1-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v0.3.1/bos-cli-v0.3.1-installer.sh | sh
+npx playwright install-deps
+npx playwright install

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build:preview": "node ./scripts/build-preview.mjs",
     "dev": "npm run dev:mainnet",
     "gateway": "node scripts/dev-gateway.mjs",
-    "test": "npx playwright test"
+    "test": "npx playwright test",
+    "test:watch:codespaces": "npm test -- --ui-host=0.0.0.0"
   },
   "simple-git-hooks": {
     "pre-commit": "npm run fmt"

--- a/playwright-tests/storage-states/wallet-connected-moderator.json
+++ b/playwright-tests/storage-states/wallet-connected-moderator.json
@@ -1,0 +1,27 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:8080",
+      "localStorage": [
+        {
+          "name": "near-wallet-selector:selectedWalletId",
+          "value": "near-wallet"
+        },
+        {
+          "name": "near_app_wallet_auth_key",
+          "value": "{\"accountId\":\"neardevdao.near\"}"
+        },
+        {
+          "name": "near-social-vm:v01::accountId:",
+          "value": "neardevdao.near"
+        },
+        {
+          "name": "flags",
+          "value": "{\"bosLoaderUrl\":\"http://127.0.0.1:3030\"}"
+        }
+      ]
+    }
+  ],
+  "sessionStorage": []
+}

--- a/playwright-tests/tests/create.spec.js
+++ b/playwright-tests/tests/create.spec.js
@@ -28,7 +28,7 @@ test.describe("Wallet is connected", () => {
     storageState: "playwright-tests/storage-states/wallet-connected.json",
   });
 
-  test("should be able to submit a solution with USDC as currency", async ({
+  test("should be able to submit a solution (funding request) with USDC as currency", async ({
     page,
   }) => {
     await page.goto("/devhub.near/widget/app?page=create");
@@ -41,12 +41,43 @@ test.describe("Wallet is connected", () => {
       "The test title"
     );
 
+    const descriptionInput = page
+      .frameLocator("iframe")
+      .locator(".CodeMirror textarea");
+    await descriptionInput.focus();
+    await descriptionInput.fill("Developer contributor report by somebody");
+
+    const tagsInput = page.locator(".rbt-input-multi");
+    await tagsInput.focus();
+    await tagsInput.pressSequentially("paid-cont", { delay: 100 });
+    await tagsInput.press("Tab");
+    await tagsInput.pressSequentially("developer-da", { delay: 100 });
+    await tagsInput.press("Tab");
+
     await page.click('label:has-text("Yes") button');
     await selectAndAssert(page, 'div:has-text("Currency") select', "USDT");
     await setInputAndAssert(
       page,
       'input[data-testid="requested-amount-editor"]',
       "300"
+    );
+    await page.click('button:has-text("Submit")');
+    await expect(page.locator("div.modal-body code")).toHaveText(
+      JSON.stringify(
+        {
+          parent_id: null,
+          labels: ["paid-contributor", "developer-dao"],
+          body: {
+            name: "The test title",
+            description:
+              "###### Requested amount: 300 USDT\n###### Requested sponsor: @neardevdao.near\nDeveloper contributor report by somebody",
+            post_type: "Solution",
+            solution_version: "V1",
+          },
+        },
+        null,
+        1
+      )
     );
   });
 

--- a/playwright-tests/tests/funding.spec.js
+++ b/playwright-tests/tests/funding.spec.js
@@ -1,0 +1,127 @@
+import { expect, test } from "@playwright/test";
+import { selectAndAssert, setInputAndAssert } from "../testUtils";
+
+test.describe("Wallet is connected", () => {
+  // sign in to wallet
+  test.use({
+    storageState: "playwright-tests/storage-states/wallet-connected.json",
+  });
+
+  test("should be able to submit a solution (funding request)", async ({
+    page,
+  }) => {
+    await page.goto("/devhub.near/widget/app?page=create");
+
+    await page.click('button:has-text("Solution")');
+
+    await setInputAndAssert(
+      page,
+      'input[data-testid="name-editor"]',
+      "The test title"
+    );
+
+    const descriptionInput = page
+      .frameLocator("iframe")
+      .locator(".CodeMirror textarea");
+    await descriptionInput.focus();
+    await descriptionInput.fill("Developer contributor report by somebody");
+
+    const tagsInput = page.locator(".rbt-input-multi");
+    await tagsInput.focus();
+    await tagsInput.pressSequentially("paid-cont", { delay: 100 });
+    await tagsInput.press("Tab");
+    await tagsInput.pressSequentially("developer-da", { delay: 100 });
+    await tagsInput.press("Tab");
+
+    await page.click('label:has-text("Yes") button');
+    await selectAndAssert(page, 'div:has-text("Currency") select', "USDT");
+    await setInputAndAssert(
+      page,
+      'input[data-testid="requested-amount-editor"]',
+      "300"
+    );
+    await page.click('button:has-text("Submit")');
+    await expect(page.locator("div.modal-body code")).toHaveText(
+      JSON.stringify(
+        {
+          parent_id: null,
+          labels: ["paid-contributor", "developer-dao"],
+          body: {
+            name: "The test title",
+            description:
+              "###### Requested amount: 300 USDT\n###### Requested sponsor: @neardevdao.near\nDeveloper contributor report by somebody",
+            post_type: "Solution",
+            solution_version: "V1",
+          },
+        },
+        null,
+        1
+      )
+    );
+  });
+});
+test.describe("Wallet is connected by moderator", () => {
+  test.use({
+    storageState:
+      "playwright-tests/storage-states/wallet-connected-moderator.json",
+  });
+
+  test("should be able to approve a funding request", async ({ page }) => {
+    await page.goto("/devhub.near/widget/app?page=post&id=2586");
+    await page.click('button:has-text("Reply")');
+    await page.click('li:has-text("Sponsorship")');
+
+    const tagsInput = page.getByText("Labels:").locator(".rbt-input-multi");
+    await tagsInput.click();
+    await tagsInput.pressSequentially("funding", { delay: 100 });
+    await tagsInput.press("Tab");
+    await tagsInput.pressSequentially("funding-information-coll", {
+      delay: 100,
+    });
+    await tagsInput.press("Tab");
+
+    await page
+      .getByText("Title:")
+      .getByRole("textbox")
+      .fill("Sponsorship: DevHub Platform Development Work");
+    await page
+      .getByText("Amount:", { exact: true })
+      .getByRole("textbox")
+      .fill("7050");
+    await (await page.getByLabel("Select currency")).selectOption("USDC");
+
+    const descriptionInput = page
+      .frameLocator("iframe")
+      .locator(".CodeMirror textarea");
+    await descriptionInput.focus();
+    await descriptionInput.fill(
+      "Congrats on getting your funding request approved"
+    );
+
+    await page.click('button:has-text("Submit")');
+    await expect(page.locator("div.modal-body code")).toHaveText(
+      JSON.stringify(
+        {
+          parent_id: 2586,
+          labels: ["funding", "funding-information-collection"],
+          body: {
+            name: "Sponsorship: DevHub Platform Development Work",
+            description: "Congrats on getting your funding request approved",
+            amount: "7050",
+            sponsorship_token: {
+              NEP141: {
+                address:
+                  "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
+              },
+            },
+            supervisor: "neardevdao.near",
+            sponsorship_version: "V1",
+            post_type: "Sponsorship",
+          },
+        },
+        null,
+        1
+      )
+    );
+  });
+});


### PR DESCRIPTION
- Github codespaces setup
- From codespaces, trigger test UI using `npm test:watch:codespaces`
- Extend USDC test to also verify transaction contents, and added description and tags content
- Test of a funding request and approval by moderator

See a demo video here for Github Codespaces and Playwright UI: https://youtu.be/urO50ZYvt-8

Part of resolving #593