### PR TITLE
auto close after posting

### DIFF
--- a/src/devhub/entity/post/PostEditor.jsx
+++ b/src/devhub/entity/post/PostEditor.jsx
@@ -263,6 +263,7 @@ const onSubmit = () => {
       });
     }
     Near.call(txn);
+
   }
 };
 
@@ -581,141 +582,159 @@ function generateDescription(text, amount, token, supervisor, seekingFunding) {
 }
 
 const [tab, setTab] = useState("editor");
+const [numPosts, setNumPosts] = useState(null);
+const [numPostsChanged, setNumPostsChanged] = useState(false);
+useEffect(() => {
+  const all_post_ids = Near.view("${REPL_DEVHUB_CONTRACT}", 'get_all_post_ids');
+  if (all_post_ids) {
+    console.log(numPosts, all_post_ids.length);
+    if (numPosts !=null && numPosts != all_post_ids.length) {
+      console.log('numPosts changed');
+      setNumPostsChanged(true);
+    }
+    setNumPosts(all_post_ids.length);
+  }
+});
 
 const renamedPostType = postType == "Submission" ? "Solution" : postType;
 // Below there is a weird code with fields.includes("githubLink") ternary operator.
 // This is to hack around rendering bug of near.social.
-return (
-  <div className="card">
-    <div className="card-header">
-      <div>
-        <ul class="nav nav-tabs">
-          <li class="nav-item">
-            <button
-              class={`nav-link ${tab === "editor" ? "active" : ""}`}
-              onClick={() => setTab("editor")}
-            >
-              Editor
-            </button>
-          </li>
-          <li class="nav-item">
-            <button
-              class={`nav-link ${tab === "preview" ? "active" : ""}`}
-              onClick={() => setTab("preview")}
-            >
-              Preview
-            </button>
-          </li>
-        </ul>
+if (!numPostsChanged) {
+  return (
+    <div className="card">
+      <div className="card-header">
+        num Posts: {numPosts}. New posts added: {numPostsChanged}
+        <div>
+          <ul class="nav nav-tabs">
+            <li class="nav-item">
+              <button
+                class={`nav-link ${tab === "editor" ? "active" : ""}`}
+                onClick={() => setTab("editor")}
+              >
+                Editor
+              </button>
+            </li>
+            <li class="nav-item">
+              <button
+                class={`nav-link ${tab === "preview" ? "active" : ""}`}
+                onClick={() => setTab("preview")}
+              >
+                Preview
+              </button>
+            </li>
+          </ul>
+        </div>
+        {tab === "editor" && (
+          <div className="my-3">
+            {mode} {renamedPostType}
+          </div>
+        )}
+        {tab === "preview" && <div className="my-3">Post Preview</div>}
       </div>
+
       {tab === "editor" && (
-        <div className="my-3">
-          {mode} {renamedPostType}
+        <div class="card-body">
+          {state.warning && (
+            <div
+              class="alert alert-warning alert-dismissible fade show"
+              role="alert"
+            >
+              {state.warning}
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="alert"
+                aria-label="Close"
+                onClick={() => State.update({ warning: "" })}
+              ></button>
+            </div>
+          )}
+          {/* This statement around the githubLinkDiv creates a weird render bug
+        where the title renders extra on state change. */}
+          {fields.includes("githubLink") ? (
+            <div className="row">
+              {fields.includes("githubLink") && githubLinkDiv}
+              {labelEditor}
+              {fields.includes("name") && nameDiv}
+              {fields.includes("description") && callDescriptionDiv()}
+            </div>
+          ) : (
+            <div className="row">
+              {labelEditor}
+              {fields.includes("name") && nameDiv}
+              {fields.includes("amount") && amountDiv}
+              {fields.includes("sponsorship_token") && tokenDiv}
+              {fields.includes("supervisor") && supervisorDiv}
+              {fields.includes("description") && callDescriptionDiv()}
+              {fields.includes("fund_raising") && isFundraisingDiv}
+              {state.seekingFunding &&
+                fields.includes("fund_raising") &&
+                fundraisingDiv}
+            </div>
+          )}
+          <button
+            style={{
+              width: "7rem",
+              backgroundColor: "#0C7283",
+              color: "#f3f3f3",
+            }}
+            disabled={state.seekingFunding && (!state.amount || state.amount < 1)}
+            className="btn btn-light mb-2 p-3"
+            onClick={onSubmit}
+          >
+            Submit
+          </button>
+          <button
+            style={{
+              width: "7rem",
+              backgroundColor: "#fff",
+              color: "#000",
+            }}
+            className="btn btn-light mb-2 p-3"
+            onClick={toggleEditor}
+          >
+            Cancel
+          </button>
+          {disclaimer}
         </div>
       )}
-      {tab === "preview" && <div className="my-3">Post Preview</div>}
-    </div>
-
-    {tab === "editor" && (
-      <div class="card-body">
-        {state.warning && (
-          <div
-            class="alert alert-warning alert-dismissible fade show"
-            role="alert"
-          >
-            {state.warning}
-            <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="alert"
-              aria-label="Close"
-              onClick={() => State.update({ warning: "" })}
-            ></button>
-          </div>
-        )}
-        {/* This statement around the githubLinkDiv creates a weird render bug
-      where the title renders extra on state change. */}
-        {fields.includes("githubLink") ? (
-          <div className="row">
-            {fields.includes("githubLink") && githubLinkDiv}
-            {labelEditor}
-            {fields.includes("name") && nameDiv}
-            {fields.includes("description") && callDescriptionDiv()}
-          </div>
-        ) : (
-          <div className="row">
-            {labelEditor}
-            {fields.includes("name") && nameDiv}
-            {fields.includes("amount") && amountDiv}
-            {fields.includes("sponsorship_token") && tokenDiv}
-            {fields.includes("supervisor") && supervisorDiv}
-            {fields.includes("description") && callDescriptionDiv()}
-            {fields.includes("fund_raising") && isFundraisingDiv}
-            {state.seekingFunding &&
-              fields.includes("fund_raising") &&
-              fundraisingDiv}
-          </div>
-        )}
-        <button
-          style={{
-            width: "7rem",
-            backgroundColor: "#0C7283",
-            color: "#f3f3f3",
-          }}
-          disabled={state.seekingFunding && (!state.amount || state.amount < 1)}
-          className="btn btn-light mb-2 p-3"
-          onClick={onSubmit}
-        >
-          Submit
-        </button>
-        <button
-          style={{
-            width: "7rem",
-            backgroundColor: "#fff",
-            color: "#000",
-          }}
-          className="btn btn-light mb-2 p-3"
-          onClick={toggleEditor}
-        >
-          Cancel
-        </button>
-        {disclaimer}
-      </div>
-    )}
-    {tab === "preview" && (
-      <div class="card-body">
-        <Widget
-          src="${REPL_DEVHUB}/widget/devhub.entity.post.Post"
-          props={{
-            isPreview: true,
-            id: 0, // irrelevant
-            post: {
-              author_id: state.author_id,
-              likes: [],
-              snapshot: {
-                editor_id: state.editor_id,
-                labels: state.labelStrings,
-                post_type: postType,
-                name: state.name,
-                description:
-                  postType == "Solution"
-                    ? generateDescription(
-                        state.description,
-                        state.amount,
-                        state.token,
-                        state.supervisor,
-                        state.seekingFunding
-                      )
-                    : state.description,
-                amount: state.amount,
-                sponsorship_token: state.token,
-                supervisor: state.supervisor,
-                github_link: state.githubLink,
+      {tab === "preview" && (
+        <div class="card-body">
+          <Widget
+            src="${REPL_DEVHUB}/widget/devhub.entity.post.Post"
+            props={{
+              isPreview: true,
+              id: 0, // irrelevant
+              post: {
+                author_id: state.author_id,
+                likes: [],
+                snapshot: {
+                  editor_id: state.editor_id,
+                  labels: state.labelStrings,
+                  post_type: postType,
+                  name: state.name,
+                  description:
+                    postType == "Solution"
+                      ? generateDescription(
+                          state.description,
+                          state.amount,
+                          state.token,
+                          state.supervisor,
+                          state.seekingFunding
+                        )
+                      : state.description,
+                  amount: state.amount,
+                  sponsorship_token: state.token,
+                  supervisor: state.supervisor,
+                  github_link: state.githubLink,
+                },
               },
-            },
-          }}
-        />
-      </div>
-    )}
-  </div>
-);
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+} else {
+  return <></>;
+}


### PR DESCRIPTION
This PR is not supposed to be merged, but is just an example of how to rely on `Near.View` cache invalidation implemented in [this PR to the VM](https://github.com/NearSocial/VM/pull/156), to detect when the editor can be closed after creating a post.

https://youtu.be/xbxX3DVHFno

@Megha-Dev-19 