### PR TITLE
fix(test): flaky solution/sponsorship tests

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -36,6 +36,5 @@ jobs:
           npx playwright install
       - name: Run tests
         run: |
-          set -e
           npx playwright test
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -35,6 +35,7 @@ jobs:
           npx playwright install-deps
           npx playwright install
       - name: Run tests
-        run: |          
+        run: |
+          set -e
           npx playwright test
 

--- a/playwright-tests/tests/funding.spec.js
+++ b/playwright-tests/tests/funding.spec.js
@@ -14,11 +14,7 @@ test.describe("Wallet is connected", () => {
 
     await page.click('button:has-text("Solution")');
 
-    await setInputAndAssert(
-      page,
-      'input[data-testid="name-editor"]',
-      "The test title"
-    );
+    await page.getByTestId("name-editor").fill("The test title");
 
     const descriptionInput = page
       .frameLocator("iframe")
@@ -35,11 +31,8 @@ test.describe("Wallet is connected", () => {
 
     await page.click('label:has-text("Yes") button');
     await selectAndAssert(page, 'div:has-text("Currency") select', "USDT");
-    await setInputAndAssert(
-      page,
-      'input[data-testid="requested-amount-editor"]',
-      "300"
-    );
+    await page.getByTestId("requested-amount-editor").fill("300");
+
     await page.click('button:has-text("Submit")');
     await expect(page.locator("div.modal-body code")).toHaveText(
       JSON.stringify(
@@ -71,16 +64,6 @@ test.describe("Wallet is connected by moderator", () => {
     await page.click('button:has-text("Reply")');
     await page.click('li:has-text("Sponsorship")');
 
-    const tagsInput = page.getByText("Labels:").locator(".rbt-input-multi");
-    await tagsInput.click();
-    await tagsInput.pressSequentially("funding", { delay: 100 });
-    await tagsInput.press("Tab");
-    await tagsInput.pressSequentially("funding-information-coll", {
-      delay: 100,
-    });
-    await tagsInput.press("Tab");
-    await tagsInput.blur();
-
     await page
       .getByText("Title:")
       .getByRole("textbox")
@@ -90,7 +73,8 @@ test.describe("Wallet is connected by moderator", () => {
       .getByText("Amount:", { exact: true })
       .getByRole("textbox")
       .fill("7050");
-    await (await page.getByLabel("Select currency")).selectOption("USDC");
+
+    await page.getByLabel("Select currency").selectOption("USDC");
 
     const descriptionInput = page
       .frameLocator("iframe")
@@ -99,7 +83,15 @@ test.describe("Wallet is connected by moderator", () => {
     await descriptionInput.fill(
       "Congrats on getting your funding request approved"
     );
-    await descriptionInput.blur();
+
+    const tagsInput = page.getByText("Labels:").locator(".rbt-input-multi");
+    await tagsInput.click();
+    await tagsInput.pressSequentially("funding", { delay: 100 });
+    await tagsInput.press("Tab");
+    await tagsInput.pressSequentially("funding-information-coll", {
+      delay: 100,
+    });
+    await tagsInput.press("Tab");
 
     await page.click('button:has-text("Submit")');
 

--- a/playwright-tests/tests/funding.spec.js
+++ b/playwright-tests/tests/funding.spec.js
@@ -79,11 +79,13 @@ test.describe("Wallet is connected by moderator", () => {
       delay: 100,
     });
     await tagsInput.press("Tab");
+    await tagsInput.blur();
 
     await page
       .getByText("Title:")
       .getByRole("textbox")
       .fill("Sponsorship: DevHub Platform Development Work");
+
     await page
       .getByText("Amount:", { exact: true })
       .getByRole("textbox")
@@ -97,9 +99,16 @@ test.describe("Wallet is connected by moderator", () => {
     await descriptionInput.fill(
       "Congrats on getting your funding request approved"
     );
+    await descriptionInput.blur();
 
     await page.click('button:has-text("Submit")');
-    await expect(page.locator("div.modal-body code")).toHaveText(
+
+    const transactionText = JSON.stringify(
+      JSON.parse(await page.locator("div.modal-body code").innerText()),
+      null,
+      1
+    );
+    await expect(transactionText).toEqual(
       JSON.stringify(
         {
           parent_id: 2586,


### PR DESCRIPTION
- parse and stringify transaction text content to avoid flakyness caused by whitespace diff
- use `locator` instead of `selectAndAssert`

