### PR TITLE
fix(discussions): content match before repost on discussions

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,6 +2,6 @@
 
 npm install
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mpeterdev/bos-loader/releases/download/v0.7.1/bos-loader-v0.7.1-installer.sh | sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v0.3.1/bos-cli-v0.3.1-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/bos-cli-rs/bos-cli-rs/releases/latest/download/bos-cli-installer.sh | sh
 npx playwright install-deps
 npx playwright install

--- a/playwright-tests/storage-states/wallet-connected-peter.json
+++ b/playwright-tests/storage-states/wallet-connected-peter.json
@@ -1,0 +1,27 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:8080",
+      "localStorage": [
+        {
+          "name": "near-wallet-selector:selectedWalletId",
+          "value": "near-wallet"
+        },
+        {
+          "name": "near_app_wallet_auth_key",
+          "value": "{\"accountId\":\"petersalomonsen.near\"}"
+        },
+        {
+          "name": "near-social-vm:v01::accountId:",
+          "value": "petersalomonsen.near"
+        },
+        {
+          "name": "flags",
+          "value": "{\"bosLoaderUrl\":\"http://127.0.0.1:3030\"}"
+        }
+      ]
+    }
+  ],
+  "sessionStorage": []
+}

--- a/playwright-tests/tests/addons.spec.js
+++ b/playwright-tests/tests/addons.spec.js
@@ -2,12 +2,12 @@ const { test } = require("@playwright/test");
 
 test.describe("Wallet is connected", () => {
   test.use({
-    storageState: "playwright-tests/storage-states/wallet-connected.json",
+    storageState: "playwright-tests/storage-states/wallet-connected-peter.json",
   });
 
   test.describe("AddonsConfigurator", () => {
     const baseUrl =
-      "/devhub.near/widget/app?page=community.configuration&handle=devhub-test";
+      "/devhub.near/widget/app?page=community.configuration&handle=webassemblymusic";
     // const dropdownSelector =
     //   'input[data-component="near/widget/DIG.InputSelect"]';
     // const addButtonSelector = "button.btn-success:has(i.bi.bi-plus)";

--- a/playwright-tests/tests/announcements.spec.js
+++ b/playwright-tests/tests/announcements.spec.js
@@ -7,7 +7,7 @@ test.describe("Non authenticated user's wallet is connected", () => {
 
   test("compose does not show for unauthenticated user", async ({ page }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
 
     const composeTextareaSelector = await page.$(
@@ -19,12 +19,12 @@ test.describe("Non authenticated user's wallet is connected", () => {
 
 test.describe("Admin wallet is connected", () => {
   test.use({
-    storageState: "playwright-tests/storage-states/wallet-connected-admin.json",
+    storageState: "playwright-tests/storage-states/wallet-connected-peter.json",
   });
 
   test("compose shows for admins and moderators users", async ({ page }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
 
     const composeTextareaSelector = `textarea[data-testid="compose-announcement"]`;
@@ -35,7 +35,7 @@ test.describe("Admin wallet is connected", () => {
 
   test("contract call is correct after commit", async ({ page }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
     const composeTextareaSelector = `textarea[data-testid="compose-announcement"]`;
     // Wait for the compose area to be visible
@@ -52,7 +52,7 @@ test.describe("Admin wallet is connected", () => {
     await expect(page.locator("div.modal-body code")).toHaveText(
       JSON.stringify(
         {
-          handle: "devhub-test",
+          handle: "webassemblymusic",
           data: {
             post: {
               main: '{"type":"md","text":"Annoncements is live!"}',
@@ -70,7 +70,7 @@ test.describe("Admin wallet is connected", () => {
 
   test("comment button is visible", async ({ page }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
     const commentButtonSelector = `button[title="Add Comment"]`;
     await page.waitForSelector(commentButtonSelector, {
@@ -80,7 +80,7 @@ test.describe("Admin wallet is connected", () => {
 
   test("like button is visible", async ({ page }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
     const likeButtonSelector = `button[title="Like"]`;
     await page.waitForSelector(likeButtonSelector, {
@@ -90,7 +90,7 @@ test.describe("Admin wallet is connected", () => {
 
   test("a post shows in feed", async ({ page }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
     const postLocator = page.locator(".post").first();
     await postLocator.focus();
@@ -101,7 +101,7 @@ test.describe("Admin wallet is connected", () => {
     // This test needs to be revisited if we modify the post / comment
     // At this time comments occur within "near" accountId's widgets with no discernable traits for testing
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
     // only comments have a row class
     const commentsDivSelector = `i[class="bi-chat"]`;

--- a/playwright-tests/tests/community.spec.js
+++ b/playwright-tests/tests/community.spec.js
@@ -1,10 +1,12 @@
 import { test, expect } from "@playwright/test";
 
 test("should load a community page if handle exists", async ({ page }) => {
-  await page.goto("/devhub.near/widget/app?page=community&handle=devhub-test");
+  await page.goto(
+    "/devhub.near/widget/app?page=community&handle=webassemblymusic"
+  );
 
   // Using the <Link> that wraps the tabs to identify a community page loaded
-  const communityTabSelector = `a[href^="/devhub.near/widget/app?page=community&handle=devhub-test&tab="]`;
+  const communityTabSelector = `a[href^="/devhub.near/widget/app?page=community&handle=webassemblymusic&tab="]`;
 
   // Wait for the tab to be visible
   await page.waitForSelector(communityTabSelector, {
@@ -35,14 +37,14 @@ test("should load an error page if handle does not exist", async ({ page }) => {
 
 test.describe("Wallet is connected", () => {
   test.use({
-    storageState: "playwright-tests/storage-states/wallet-connected.json",
+    storageState: "playwright-tests/storage-states/wallet-connected-peter.json",
   });
 
   test("should allow connected user to post from community page", async ({
     page,
   }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test&tab=activity"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=activity"
     );
 
     const postButtonSelector = 'a:has-text("Post")';
@@ -59,7 +61,7 @@ test.describe("Wallet is connected", () => {
 
     // Verify that the URL is the expected one.
     expect(page.url()).toBe(
-      "http://localhost:8080/devhub.near/widget/app?page=create&labels=devhub-test"
+      "http://localhost:8080/devhub.near/widget/app?page=create&labels=webassemblymusic"
     );
 
     // Wait for the Typeahead field to render.
@@ -76,7 +78,7 @@ test.describe("Wallet is connected", () => {
     const elementText = await element.textContent();
 
     expect(element).toBeTruthy();
-    expect(elementText).toBe("devhub-test");
+    expect(elementText).toBe("webassemblymusic");
   });
 });
 
@@ -89,7 +91,7 @@ test.describe("Wallet is not connected", () => {
     page,
   }) => {
     await page.goto(
-      "/devhub.near/widget/app?page=community&handle=devhub-test"
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
 
     const createCommunityButtonSelector = 'button:has-text("Post")';

--- a/playwright-tests/tests/discussions.spec.js
+++ b/playwright-tests/tests/discussions.spec.js
@@ -5,21 +5,118 @@ test.describe("Wallet is connected", () => {
     storageState: "playwright-tests/storage-states/wallet-connected-peter.json",
   });
 
-  test("should post to a discussion and validate content match", async ({
-    page,
-  }) => {
+  test("should create a discussion when content matches", async ({ page }) => {
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions"
     );
+
+    const socialdbaccount = "petersalomonsen.near";
+    const viewsocialdbpostresult = await fetch("https://rpc.mainnet.near.org", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "dontcare",
+        method: "query",
+        params: {
+          request_type: "call_function",
+          finality: "final",
+          account_id: "social.near",
+          method_name: "get",
+          args_base64: btoa(
+            JSON.stringify({
+              keys: [socialdbaccount + "/post/main"],
+              options: { with_block_height: true },
+            })
+          ),
+        },
+      }),
+    }).then((r) => r.json());
+
+    const socialdbpost = JSON.parse(
+      new TextDecoder().decode(
+        new Uint8Array(viewsocialdbpostresult.result.result)
+      )
+    );
+    const socialdbpostcontent = JSON.parse(
+      socialdbpost[socialdbaccount].post.main[""]
+    );
+
     const discussionPostEditor = await page.getByTestId("compose-announcement");
     await discussionPostEditor.scrollIntoViewIfNeeded();
-    await discussionPostEditor.fill("A test discussion post");
+    await discussionPostEditor.fill(socialdbpostcontent.text);
 
     await page.getByTestId("post-btn").click();
 
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions&transactionHashes=mi2a1KwagRFZhpqBNKhKaCTkHVj98J8tZnxSr1NpxSQ"
     );
+
+    await expect(page.locator("div.modal-body code")).toHaveText(
+      JSON.stringify(
+        {
+          handle: "webassemblymusic",
+          block_height: 113362773,
+        },
+        null,
+        1
+      )
+    );
+  });
+
+  test("should not create a discussion if content does not match", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions"
+    );
+
+    const socialdbaccount = "petersalomonsen.near";
+    const viewsocialdbpostresult = await fetch("https://rpc.mainnet.near.org", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "dontcare",
+        method: "query",
+        params: {
+          request_type: "call_function",
+          finality: "final",
+          account_id: "social.near",
+          method_name: "get",
+          args_base64: btoa(
+            JSON.stringify({
+              keys: [socialdbaccount + "/post/main"],
+              options: { with_block_height: true },
+            })
+          ),
+        },
+      }),
+    }).then((r) => r.json());
+
+    const socialdbpost = JSON.parse(
+      new TextDecoder().decode(
+        new Uint8Array(viewsocialdbpostresult.result.result)
+      )
+    );
+    const socialdbpostcontent = JSON.parse(
+      socialdbpost[socialdbaccount].post.main[""]
+    );
+
+    const discussionPostEditor = await page.getByTestId("compose-announcement");
+    await discussionPostEditor.scrollIntoViewIfNeeded();
+    await discussionPostEditor.fill(
+      socialdbpostcontent.text + " something else so that it does not match"
+    );
+
+    await page.getByTestId("post-btn").click();
+
+    await page.goto(
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions&transactionHashes=mi2a1KwagRFZhpqBNKhKaCTkHVj98J8tZnxSr1NpxSQ"
+    );
+
+    const transactionConfirmationModal = page.locator("div.modal-body code");
     await page.waitForTimeout(4000);
+    expect(await transactionConfirmationModal.isVisible()).toBeFalsy();
   });
 });

--- a/playwright-tests/tests/discussions.spec.js
+++ b/playwright-tests/tests/discussions.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Wallet is connected", () => {
+  test.use({
+    storageState: "playwright-tests/storage-states/wallet-connected-peter.json",
+  });
+
+  test("should post to a discussion and validate content match", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions"
+    );
+    const discussionPostEditor = await page.getByTestId("compose-announcement");
+    await discussionPostEditor.scrollIntoViewIfNeeded();
+    await discussionPostEditor.fill("A test discussion post");
+
+    await page.getByTestId("post-btn").click();
+
+    await page.goto(
+      "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions&transactionHashes=mi2a1KwagRFZhpqBNKhKaCTkHVj98J8tZnxSr1NpxSQ"
+    );
+    await page.waitForTimeout(4000);
+  });
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -33,6 +33,7 @@ export default defineConfig({
   reporter: "line",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
+    video: "off",
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/scripts/build-preview.mjs
+++ b/scripts/build-preview.mjs
@@ -42,6 +42,13 @@ if (!ACCOUNT_ID) {
   console.error(
     "Error: Account is not provided. Please provide the account to deploy the widgets to."
   );
+console.log(`\nExample usage:\n
+npm run build:preview -- -a devgovgigs.petersalomonsen.near -c devhub.near
+
+Arguments: 
+-a account for deploying BOS components
+-c backend contract account
+`)
   process.exit(1);
 }
 

--- a/src/devhub/entity/community/Discussions.jsx
+++ b/src/devhub/entity/community/Discussions.jsx
@@ -88,7 +88,6 @@ function repostOnDiscussions(blockHeight) {
 }
 
 async function checkHashes() {
-  console.log("checkHashes", props.transactionHashes);
   if (props.transactionHashes) {
     asyncFetch("${REPL_RPC_URL}", {
       method: "POST",


### PR DESCRIPTION
Check the new discussion posted content with the post on SocialDB, and wait for it to match before reposting on discussions with `blockHeight`. This is to ensure that we don't repost the reference of a previous SocialDB post.

Preview URL: https://near.social/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions


Here's a video for one of the tests, when the content match, then the `create_discussion` confirmation dialog will show. The other test, where the content does not match, is just verifying that the dialog does not show after some seconds.


https://github.com/NEAR-DevHub/neardevhub-bos/assets/9760441/3b63b877-cb58-4939-96f7-dda8841abcdb

