### PR TITLE
Feature/690 filter search proposals

### DIFF
--- a/src/devhub/components/molecule/DropDown.jsx
+++ b/src/devhub/components/molecule/DropDown.jsx
@@ -44,7 +44,13 @@ return (
             <li
               style={{ borderRadius: "5px" }}
               class="dropdown-item cursor-pointer link-underline link-underline-opacity-0"
-              onClick={() => setSelected(item)}
+              onClick={() => {
+                if (selected.label !== item.label) {
+                  setSelected(item);
+                } else {
+                  setSelected(null);
+                }
+              }}
             >
               {item.label}
             </li>

--- a/src/devhub/components/molecule/Input.jsx
+++ b/src/devhub/components/molecule/Input.jsx
@@ -120,15 +120,19 @@ const TextInput = ({
       {!multiline ? (
         <div className="input-group">
           {inputProps.prefix && (
-            <span className="input-group-text">{inputProps.prefix}</span>
+            <span className="input-group-text bg-white border-end-0">
+              {inputProps.prefix}
+            </span>
           )}
           <input
             aria-describedby={key}
             data-testid={key}
             aria-label={label}
-            className={["form-control border border-2", inputClassName].join(
-              " "
-            )}
+            className={[
+              "form-control border",
+              inputClassName,
+              inputProps.prefix ? "border-start-0" : "",
+            ].join(" ")}
             type={typeAttribute}
             maxLength={inputProps.max}
             value={state.data}
@@ -142,7 +146,7 @@ const TextInput = ({
           aria-describedby={key}
           data-testid={key}
           aria-label={label}
-          className={["form-control border border-2", inputClassName].join(" ")}
+          className={["form-control border", inputClassName].join(" ")}
           placeholder={
             placeholder + (inputProps.required ? " ( required )" : "")
           }

--- a/src/devhub/components/molecule/Input.jsx
+++ b/src/devhub/components/molecule/Input.jsx
@@ -96,6 +96,8 @@ const TextInput = ({
     ) : null,
   ].filter((label) => label !== null);
 
+  const onKeyDown = props.onKeyDown ?? (() => {});
+
   return (
     <div
       className={[
@@ -131,6 +133,7 @@ const TextInput = ({
             maxLength={inputProps.max}
             value={state.data}
             onChange={(e) => State.update({ data: e.target.value })}
+            onKeyDown={onKeyDown}
             {...{ placeholder, ...inputProps }}
           />
         </div>
@@ -148,6 +151,7 @@ const TextInput = ({
           maxLength={inputProps.max}
           value={state.data}
           onChange={(e) => State.update({ data: e.target.value })}
+          onKeyDown={onKeyDown}
           {...{ placeholder, ...inputProps }}
         />
       )}

--- a/src/devhub/entity/proposal/Feed.jsx
+++ b/src/devhub/entity/proposal/Feed.jsx
@@ -185,8 +185,6 @@ const FeedPage = () => {
       timeline
     }
     ${queryName}_aggregate(
-      offset: $offset
-      limit: $limit
       order_by: {proposal_id: desc}
       where: $where
     )  {

--- a/src/devhub/entity/proposal/Feed.jsx
+++ b/src/devhub/entity/proposal/Feed.jsx
@@ -61,7 +61,6 @@ const Heading = styled.div`
 const FeedItem = ({ proposal }) => {
   const accountId = proposal.author_id;
   const profile = Social.get(`${accountId}/profile/**`, "final");
-  // FIXME: social_db_post_block_height is only know in proposal not the body. Which means it won't be indexed.
   // We will have to get the proposal from the contract to get the block height.
   const blockHeight = parseInt(proposal.social_db_post_block_height);
   const item = {

--- a/src/devhub/entity/proposal/Feed.jsx
+++ b/src/devhub/entity/proposal/Feed.jsx
@@ -52,6 +52,7 @@ const Container = styled.div`
 const Heading = styled.div`
   font-size: 24px;
   font-weight: 700;
+  width: 100%;
 
   @media screen and (max-width: 768px) {
     font-size: 18px;
@@ -195,7 +196,6 @@ const FeedPage = () => {
     }
   }`;
   function fetchGraphQL(operationsDoc, operationName, variables) {
-    console.log({ variables });
     return asyncFetch(QUERYAPI_ENDPOINT, {
       method: "POST",
       headers: { "x-hasura-role": `thomasguntenaar_near` },
@@ -253,7 +253,6 @@ const FeedPage = () => {
       offset,
       where: buildWhereClause(),
     };
-    console.log({ variables });
     fetchGraphQL(query, "GetLatestSnapshot", variables).then(async (result) => {
       if (result.status === 200) {
         if (result.body.data) {
@@ -263,7 +262,6 @@ const FeedPage = () => {
           const totalResult =
             result.body.data
               .thomasguntenaar_near_devhub_proposals_november_proposals_with_latest_snapshot_aggregate;
-          console.log({ data, count: totalResult.aggregate.count });
           State.update({ aggregatedCount: totalResult.aggregate.count });
           // Parse timeline
           fetchBlockHeights(data);
@@ -293,19 +291,19 @@ const FeedPage = () => {
     <Container className="w-100 py-4 px-2 d-flex flex-column gap-3">
       <div className="d-flex justify-content-between flex-wrap gap-2 align-items-center">
         <Heading>
-          DevDAO Proposals{" "}
+          DevDAO Proposals
           <span className="text-muted">
-            {" "}
             ({aggregatedCount ?? state.data.length})
           </span>
         </Heading>
-        <div className="d-flex gap-4 align-items-center">
+        <div className="d-flex flex-wrap gap-4 align-items-center">
           <Widget
             src={
               "${REPL_DEVHUB}/widget/devhub.feature.proposal-search.by-input"
             }
             props={{
               search: state.input,
+              className: "w-xs-100",
               onSearch: (input) => {
                 State.update({ input });
                 fetchProposals();
@@ -324,38 +322,40 @@ const FeedPage = () => {
               },
             }}
           /> */}
-          <Widget
-            src={
-              "${REPL_DEVHUB}/widget/devhub.feature.proposal-search.by-category"
-            }
-            props={{
-              onStateChange: (select) => {
-                State.update({ category: select.value });
-              },
-            }}
-          />
-          <Widget
-            src={
-              "${REPL_DEVHUB}/widget/devhub.feature.proposal-search.by-stage"
-            }
-            props={{
-              onStateChange: (select) => {
-                State.update({ stage: select.value });
-              },
-            }}
-          />
-          <Widget
-            src={
-              "${REPL_DEVHUB}/widget/devhub.feature.proposal-search.by-author"
-            }
-            props={{
-              onAuthorChange: (select) => {
-                State.update({ author: select.value });
-              },
-            }}
-          />
+          <div className="d-flex gap-4 align-items-center">
+            <Widget
+              src={
+                "${REPL_DEVHUB}/widget/devhub.feature.proposal-search.by-category"
+              }
+              props={{
+                onStateChange: (select) => {
+                  State.update({ category: select.value });
+                },
+              }}
+            />
+            <Widget
+              src={
+                "${REPL_DEVHUB}/widget/devhub.feature.proposal-search.by-stage"
+              }
+              props={{
+                onStateChange: (select) => {
+                  State.update({ stage: select.value });
+                },
+              }}
+            />
+            <Widget
+              src={
+                "${REPL_DEVHUB}/widget/devhub.feature.proposal-search.by-author"
+              }
+              props={{
+                onAuthorChange: (select) => {
+                  State.update({ author: select.value });
+                },
+              }}
+            />
+          </div>
         </div>
-        <div>
+        <div className="mt-2 mt-xs-0">
           <Link
             to={href({
               widgetSrc: "${REPL_DEVHUB}/widget/app",

--- a/src/devhub/entity/proposal/Feed.jsx
+++ b/src/devhub/entity/proposal/Feed.jsx
@@ -195,6 +195,7 @@ const FeedPage = () => {
     }
   }`;
   function fetchGraphQL(operationsDoc, operationName, variables) {
+    console.log({ variables });
     return asyncFetch(QUERYAPI_ENDPOINT, {
       method: "POST",
       headers: { "x-hasura-role": `thomasguntenaar_near` },
@@ -221,7 +222,6 @@ const FeedPage = () => {
       where = {
         timeline: { _cast: { String: { _ilike: `%${state.stage}%` } } },
       };
-      // where = { timeline: { _ilike: `%${state.stage}%` }, ...where };
     }
 
     if (state.input) {
@@ -232,12 +232,11 @@ const FeedPage = () => {
   };
 
   const buildOrderByClause = () => {
-    // TODO
     /**
-     * Most recent ->
-     * Most viewed ->
+     * Most recent -> Based on the biggest proposal_id
+     * Most viewed -> views added in indexer version 'papa'
      * Most commented -> edit indexer
-     * Unanswered ->
+     * Unanswered -> 0 comments
      */
   };
 
@@ -253,6 +252,7 @@ const FeedPage = () => {
       offset,
       where: buildWhereClause(),
     };
+    console.log({ variables });
     fetchGraphQL(query, "GetLatestSnapshot", variables).then(async (result) => {
       if (result.status === 200) {
         if (result.body.data) {
@@ -262,6 +262,7 @@ const FeedPage = () => {
           const totalResult =
             result.body.data
               .thomasguntenaar_near_devhub_proposals_november_proposals_with_latest_snapshot_aggregate;
+          console.log({ data, count: totalResult.aggregate.count });
           State.update({ aggregatedCount: totalResult.aggregate.count });
           // Parse timeline
           fetchBlockHeights(data);

--- a/src/devhub/entity/proposal/Feed.jsx
+++ b/src/devhub/entity/proposal/Feed.jsx
@@ -221,6 +221,7 @@ const FeedPage = () => {
       // timeline is stored as jsonb
       where = {
         timeline: { _cast: { String: { _ilike: `%${state.stage}%` } } },
+        ...where,
       };
     }
 
@@ -307,6 +308,7 @@ const FeedPage = () => {
               search: state.input,
               onSearch: (input) => {
                 State.update({ input });
+                fetchProposals();
               },
               onEnter: () => {
                 fetchProposals();

--- a/src/devhub/entity/proposal/Feed.jsx
+++ b/src/devhub/entity/proposal/Feed.jsx
@@ -187,7 +187,7 @@ const FeedPage = () => {
     ${queryName}_aggregate(
       offset: $offset
       limit: $limit
-      order_by: {proposal_id: asc}
+      order_by: {proposal_id: desc}
       where: $where
     )  {
       aggregate {

--- a/src/devhub/feature/proposal-search/by-author.jsx
+++ b/src/devhub/feature/proposal-search/by-author.jsx
@@ -2,7 +2,7 @@ const [authorsOptions, setAuthorsOptions] = useState([]);
 const [selectedAuthor, setSelectedAuthor] = useState(null);
 
 if (!authorsOptions.length) {
-  const data = [];
+  const data = [{ label: "None", value: "" }];
   const authors = Near.view(
     "${REPL_DEVHUB_CONTRACT}",
     "get_all_proposal_authors",

--- a/src/devhub/feature/proposal-search/by-author.jsx
+++ b/src/devhub/feature/proposal-search/by-author.jsx
@@ -26,7 +26,9 @@ return (
         label: "Author",
         onUpdate: (v) => {
           setSelectedAuthor(v);
+          props.onAuthorChange(v);
         },
+        selectedValue: props.author,
       }}
     />
   </div>

--- a/src/devhub/feature/proposal-search/by-category.jsx
+++ b/src/devhub/feature/proposal-search/by-category.jsx
@@ -31,6 +31,10 @@ const options = [
     label: "Other",
     value: "Other",
   },
+  {
+    label: "None",
+    value: "",
+  },
 ];
 
 const setSelected = props.onStateChange ?? (() => {});

--- a/src/devhub/feature/proposal-search/by-category.jsx
+++ b/src/devhub/feature/proposal-search/by-category.jsx
@@ -1,15 +1,39 @@
 const options = [
-  { label: "Awareness & Engagement", value: "" },
-  { label: "Community Groups / Work Groups", value: "" },
-  { label: "DevDAO Operations", value: "" },
-  { label: "Developer Relations", value: "" },
-  { label: "Events & Hackathons", value: "" },
-  { label: "Platform", value: "" },
-  { label: "Tooling & Infrastructure", value: "" },
-  { label: "Universities & Bootcamps", value: "" },
+  {
+    label: "DevDAO Operations",
+    value: "DevDAO Operations",
+  },
+  {
+    label: "DevDAO Platform",
+    value: "DevDAO Platform",
+  },
+  {
+    label: "Events & Hackathons",
+    value: "Events & Hackathons",
+  },
+  {
+    label: "Engagement & Awareness",
+    value: "Engagement & Awareness",
+  },
+  {
+    label: "Decentralized DevRel",
+    value: "Decentralized DevRel",
+  },
+  {
+    label: "Universities & Bootcamps",
+    value: "Universities & Bootcamps",
+  },
+  {
+    label: "Tooling & Infrastructure",
+    value: "Tooling & Infrastructure",
+  },
+  {
+    label: "Other",
+    value: "Other",
+  },
 ];
 
-const [selected, setSelected] = useState(null);
+const setSelected = props.onStateChange ?? (() => {});
 
 return (
   <div>

--- a/src/devhub/feature/proposal-search/by-input.jsx
+++ b/src/devhub/feature/proposal-search/by-input.jsx
@@ -26,6 +26,7 @@ return (
       onChange: (e) => {
         updateInput(e.target.value);
       },
+      onKeyDown: (e) => e.key == "Enter" && onEnter(),
       skipPaddingGap: true,
       placeholder: "Search by content",
       inputProps: {

--- a/src/devhub/feature/proposal-search/by-input.jsx
+++ b/src/devhub/feature/proposal-search/by-input.jsx
@@ -17,11 +17,13 @@ useEffect(() => {
   }
 }, [search]);
 
+const className = props.className ?? "";
+
 return (
   <Widget
     src="${REPL_DEVHUB}/widget/devhub.components.molecule.Input"
     props={{
-      className: "flex-grow-1",
+      className: "flex-grow-1 w-100" + className,
       value: search,
       onChange: (e) => {
         updateInput(e.target.value);

--- a/src/devhub/feature/proposal-search/by-sort.jsx
+++ b/src/devhub/feature/proposal-search/by-sort.jsx
@@ -1,11 +1,11 @@
 const options = [
-  { label: "Most recent", value: "" },
-  { label: "Most viewed", value: "" },
-  { label: "Most commented", value: "" },
-  { label: "Unanswered", value: "" },
+  { label: "Most recent", value: "" }, // proposal_id desc
+  { label: "Most viewed", value: "" }, // views desc
+  { label: "Most commented", value: "" }, // comments desc
+  { label: "Unanswered", value: "" }, // where comments = 0
 ];
 
-const [selected, setSelected] = useState(null);
+const setSelected = props.onStateChange ?? (() => {});
 
 return (
   <div>

--- a/src/devhub/feature/proposal-search/by-sort.jsx
+++ b/src/devhub/feature/proposal-search/by-sort.jsx
@@ -3,6 +3,7 @@ const options = [
   { label: "Most viewed", value: "" }, // views desc
   { label: "Most commented", value: "" }, // comments desc
   { label: "Unanswered", value: "" }, // where comments = 0
+  { label: "None", value: "" }, // where comments = 0
 ];
 
 const setSelected = props.onStateChange ?? (() => {});

--- a/src/devhub/feature/proposal-search/by-sort.jsx
+++ b/src/devhub/feature/proposal-search/by-sort.jsx
@@ -1,8 +1,9 @@
 const options = [
-  { label: "Most recent", value: "" }, // proposal_id desc
-  { label: "Most viewed", value: "" }, // views desc
-  { label: "Most commented", value: "" }, // comments desc
-  { label: "Unanswered", value: "" }, // where comments = 0
+  { label: "Most recent", value: "proposal_id" }, // proposal_id desc
+  { label: "Most viewed", value: "views" }, // views desc
+  // TODO add track_comments function to devhub to track it in the indexer
+  // { label: "Most commented", value: "" }, // comments desc
+  // { label: "Unanswered", value: "" }, // where comments = 0
   { label: "None", value: "" }, // where comments = 0
 ];
 
@@ -15,6 +16,7 @@ return (
       props={{
         options: options,
         label: "Sort",
+        selectedValue: options[0],
         onUpdate: (v) => {
           setSelected(v);
         },

--- a/src/devhub/feature/proposal-search/by-stage.jsx
+++ b/src/devhub/feature/proposal-search/by-stage.jsx
@@ -9,6 +9,7 @@ const options = [
   { label: "Cancelled", value: "CANCELLED" },
   { label: "Payment Processing", value: "PAYMENT" },
   { label: "Funded", value: "FUNDED" },
+  { label: "None", value: "" },
 ];
 
 const setSelected = props.onStateChange ?? (() => {});

--- a/src/devhub/feature/proposal-search/by-stage.jsx
+++ b/src/devhub/feature/proposal-search/by-stage.jsx
@@ -1,15 +1,17 @@
+// The timeline is stored in jsonb. The value is used to search for as part of
+// that json so it doesn't need to be an exact match.
 const options = [
-  { label: "Draft", value: "" },
-  { label: "Review", value: "" },
-  { label: "Approved", value: "" },
-  { label: "Approved  - Conditional", value: "" },
-  { label: "Rejected", value: "" },
-  { label: "Canceled", value: "" },
-  { label: "Payment Processing", value: "" },
-  { label: "Funded", value: "" },
+  { label: "Draft", value: "DRAFT" },
+  { label: "Review", value: "REVIEW" },
+  { label: "Approved", value: "APPROVED" },
+  { label: "Approved - Conditional", value: "CONDITIONAL" },
+  { label: "Rejected", value: "REJECTED" },
+  { label: "Cancelled", value: "CANCELLED" },
+  { label: "Payment Processing", value: "PAYMENT" },
+  { label: "Funded", value: "FUNDED" },
 ];
 
-const [selected, setSelected] = useState(null);
+const setSelected = props.onStateChange ?? (() => {});
 
 return (
   <div>


### PR DESCRIPTION
_Resolves #690_
[PREVIEW](https://near.org/thomasguntenaar.near/widget/app?page=proposals)

This PR fixes the search / filters on the new proposals page. The only thing that still has to happen is the sorting functionality. More specifically sorting on comments. However because the launch is this week I discussed with @ailisp to merge the finished part already.

I'm currently still working on tracking the amount of comments per proposal. If we want to track the number of comments in the indexer, I think the easiest would be to add a function to devhub.near that is triggered together with the social.set function. That way it is easy for the indexer to track it.

Another solution might be to query that from social db indexer, which you can get all comments of a given post? Not sure we can query another indexer from this indexer's indexingLogic. So that is reason I wanted to merge this before trying that.


