### PR TITLE
fix indexer recently stopped due to queryapi bug

### DIFF
--- a/src/devhub/entity/addon/blog/Feed.jsx
+++ b/src/devhub/entity/addon/blog/Feed.jsx
@@ -25,7 +25,7 @@ const fetchGraphQL = (operationsDoc, operationName, variables) => {
 };
 
 const queryName =
-  props.queryName ?? `bo_near_devhub_v36_posts_with_latest_snapshot`;
+  props.queryName ?? `bo_near_devhub_v38_posts_with_latest_snapshot`;
 
 const query = `query DevhubPostsQuery($limit: Int = 100, $offset: Int = 0, $where: ${queryName}_bool_exp = {}) {
     ${queryName}(

--- a/src/devhub/entity/addon/blog/editor/provider.jsx
+++ b/src/devhub/entity/addon/blog/editor/provider.jsx
@@ -19,7 +19,7 @@ const fetchGraphQL = (operationsDoc, operationName, variables) => {
 };
 
 const queryName =
-  props.queryName ?? `bo_near_devhub_v17_posts_with_latest_snapshot`;
+  props.queryName ?? `bo_near_devhub_v38_posts_with_latest_snapshot`;
 
 const query = `query DevhubPostsQuery($limit: Int = 100, $offset: Int = 0, $where: ${queryName}_bool_exp = {}) {
     ${queryName}(
@@ -131,7 +131,7 @@ const handleOnCancel = (v) => {
 
 return (
   <Layout
-    data={posts.body.data.bo_near_devhub_v17_posts_with_latest_snapshot || []}
+    data={posts.body.data.bo_near_devhub_v38_posts_with_latest_snapshot || []}
     getData={handleGetData}
     onChange={handleOnChange}
     onSubmit={handleOnSubmit}

--- a/src/devhub/entity/post/List.jsx
+++ b/src/devhub/entity/post/List.jsx
@@ -16,10 +16,10 @@ if (!href) {
 const QUERYAPI_ENDPOINT = `https://near-queryapi.api.pagoda.co/v1/graphql/`;
 
 const queryName =
-  props.queryName ?? `bo_near_devhub_v36_posts_with_latest_snapshot`;
+  props.queryName ?? `bo_near_devhub_v38_posts_with_latest_snapshot`;
 const totalQueryName =
   props.totalQueryName ??
-  "bo_near_devhub_v36_posts_with_latest_snapshot_aggregate";
+  "bo_near_devhub_v38_posts_with_latest_snapshot_aggregate";
 const query = `query DevhubPostsQuery($limit: Int = 100, $offset: Int = 0, $where: ${queryName}_bool_exp = {}) {
     ${queryName}(
       limit: $limit


### PR DESCRIPTION
Fix feed not loading for recent posts after Mar. 17 and recent blog post not showing up. Root cause is a query api bug that stopped the working indexer, and still under investigation of query api team. This fix address the problem for now, but if the bug is not fixed in query api side, future posts/blogs can still not loading in some indefinite future time