### PR TITLE
fix(community): error when opening github config

### DIFF
--- a/playwright-tests/tests/community.spec.js
+++ b/playwright-tests/tests/community.spec.js
@@ -200,3 +200,28 @@ test.describe("Is chain-abstraction community admin", () => {
     await pauseIfVideoRecording(page);
   });
 });
+
+test.describe("Is contract standards community admin", () => {
+  test.use({
+    storageState: "playwright-tests/storage-states/wallet-connected-admin.json",
+  });
+
+  test("should open github addon configuration", async ({ page }) => {
+    await page.goto(
+      "/devhub.near/widget/app?page=community&handle=contract-standards&tab=github"
+    );
+    await pauseIfVideoRecording(page);
+    const configureButton = await page.getByRole("button", { name: "" });
+    await configureButton.scrollIntoViewIfNeeded();
+    await configureButton.click();
+    await pauseIfVideoRecording(page);
+    await expect(
+      await page.getByText("GitHub board configuration")
+    ).toBeVisible();
+
+    await expect(
+      await page.getByRole("button", { name: "Save" })
+    ).toBeVisible();
+    await pauseIfVideoRecording(page);
+  });
+});

--- a/playwright-tests/util/bos-loader.js
+++ b/playwright-tests/util/bos-loader.js
@@ -21,7 +21,9 @@ export async function modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFrom
         atob(requestPostData.params.args_base64)
       ).keys[0];
 
-      const response = await route.fetch({ url: "https://near.lava.build/" });
+      const response = await route.fetch({
+        url: "https://rpc.mainnet.near.org/",
+      });
       const json = await response.json();
 
       if (devComponents[social_get_key]) {

--- a/src/devhub/entity/addon/github/Configurator.jsx
+++ b/src/devhub/entity/addon/github/Configurator.jsx
@@ -66,15 +66,17 @@ const toMigrated = ({ metadata, id, ...restParams }) => ({
 });
 
 const GithubViewConfigurator = ({ kanbanBoards, permissions, onSubmit }) => {
-  const data = Object.values(kanbanBoards)?.[0];
+  kanbanBoards = [{}];
 
-  if (!data) {
+  if (!kanbanBoards) {
     return (
       <div class="alert alert-danger" role="alert">
         Loading...
       </div>
     );
   }
+
+  const data = Object.values(kanbanBoards)?.[0];
 
   const initialBoardState = Struct.typeMatch(data) ? toMigrated(data) : {};
 
@@ -478,8 +480,9 @@ const GithubViewConfigurator = ({ kanbanBoards, permissions, onSubmit }) => {
                   },
                   label: "New column",
                   disabled:
+                    parentState.columns &&
                     Object.keys(parentState.columns).length >=
-                    settings.maxColumnsNumber,
+                      settings.maxColumnsNumber,
                   icon: { type: "bootstrap_icon", variant: "bi-plus-lg" },
                   onClick: formUpdate({
                     path: ["columns"],

--- a/src/devhub/entity/addon/github/Configurator.jsx
+++ b/src/devhub/entity/addon/github/Configurator.jsx
@@ -66,17 +66,15 @@ const toMigrated = ({ metadata, id, ...restParams }) => ({
 });
 
 const GithubViewConfigurator = ({ kanbanBoards, permissions, onSubmit }) => {
-  kanbanBoards = [{}];
+  const data = kanbanBoards ? Object.values(kanbanBoards)?.[0] : {};
 
-  if (!kanbanBoards) {
+  if (!data) {
     return (
       <div class="alert alert-danger" role="alert">
         Loading...
       </div>
     );
   }
-
-  const data = Object.values(kanbanBoards)?.[0];
 
   const initialBoardState = Struct.typeMatch(data) ? toMigrated(data) : {};
 

--- a/src/devhub/page/addon.jsx
+++ b/src/devhub/page/addon.jsx
@@ -90,6 +90,17 @@ const ButtonRow = styled.div`
 
 const [view, setView] = useState(props.view || "viewer");
 
+if ("${REPL_DEVHUB}" !== "devhub.near") {
+  addonMatch.configurator_widget = addonMatch.configurator_widget.replace(
+    "devhub.near/",
+    "${REPL_DEVHUB}/"
+  );
+  addonMatch.view_widget = addonMatch.view_widget.replace(
+    "devhub.near/",
+    "${REPL_DEVHUB}/"
+  );
+}
+
 return (
   <Container>
     {permissions.can_configure && (


### PR DESCRIPTION
Preview link: https://near.org/devgovgigs.petersalomonsen.near/widget/app?page=community&handle=contract-standards&tab=github

---

This fix handles that the `kanbanBoards` incoming property is `null` or `undefined` and if there is no column object on the `parentState`.

Here's how it looks like in the test runner after the fix:

https://github.com/NEAR-DevHub/neardevhub-bos/assets/9760441/005fcf0c-79d1-44c2-a568-34a61d7e398a

Also note that in order to make preview environment work for community addons, the widget account received from the contract must be replaced with the preview environment account. This is implemented in https://github.com/NEAR-DevHub/neardevhub-bos/pull/704/files#diff-e7bf8855eb2ab74f245b0c5b0cfc1ea2fc83a3f0ee48b59ae54403e2b206bf43

fixes #703