### PR TITLE
Added updated proposal support for popup wallet

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 3 : 0,
+  retries: process.env.CI ? 6 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? "50%" : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/src/devhub/entity/proposal/Editor.jsx
+++ b/src/devhub/entity/proposal/Editor.jsx
@@ -268,6 +268,7 @@ const [showProposalPage, setShowProposalPage] = useState(false); // when user cr
 const [proposalId, setProposalId] = useState(null);
 const [proposalIdsArray, setProposalIdsArray] = useState(null);
 const [isTxnCreated, setCreateTxn] = useState(false);
+const [oldProposalData, setOldProposalData] = useState(null);
 
 if (allowDraft) {
   draftProposalData = Storage.privateGet(draftKey);
@@ -436,21 +437,36 @@ const InputContainer = ({ heading, description, children }) => {
 // show proposal created after txn approval for popup wallet
 useEffect(() => {
   if (isTxnCreated) {
-    const proposalIds = Near.view(
-      "${REPL_DEVHUB_CONTRACT}",
-      "get_all_proposal_ids"
-    );
-    if (Array.isArray(proposalIds) && !proposalIdsArray) {
-      setProposalIdsArray(proposalIds);
-    }
-    if (
-      Array.isArray(proposalIds) &&
-      Array.isArray(proposalIdsArray) &&
-      proposalIds.length !== proposalIdsArray.length
-    ) {
-      setCreateTxn(false);
-      setProposalId(proposalIds.length - 1);
-      setShowProposalPage(true);
+    if (editProposalData) {
+      setOldProposalData(editProposalData);
+      if (
+        editProposalData &&
+        typeof editProposalData === "object" &&
+        oldProposalData &&
+        typeof oldProposalData === "object" &&
+        JSON.stringify(editProposalData) !== JSON.stringify(oldProposalData)
+      ) {
+        setCreateTxn(false);
+        setProposalId(editProposalData.id);
+        setShowProposalPage(true);
+      }
+    } else {
+      const proposalIds = Near.view(
+        "${REPL_DEVHUB_CONTRACT}",
+        "get_all_proposal_ids"
+      );
+      if (Array.isArray(proposalIds) && !proposalIdsArray) {
+        setProposalIdsArray(proposalIds);
+      }
+      if (
+        Array.isArray(proposalIds) &&
+        Array.isArray(proposalIdsArray) &&
+        proposalIds.length !== proposalIdsArray.length
+      ) {
+        setCreateTxn(false);
+        setProposalId(proposalIds.length - 1);
+        setShowProposalPage(true);
+      }
     }
   }
 });


### PR DESCRIPTION
- after the txn is approved for create/edit proposal, the updated proposal show appear, instead of create form
Preview [link](https://near.social/megha19.near/widget/app?page=create-proposal)
Note: the proposals feed won't work in preview since I have used `truedove38.near` for contract and the feed uses `devhub.near`