### PR TITLE
feat: enable/disable/order community default tabs

### DIFF
--- a/playwright-tests/tests/announcements.spec.js
+++ b/playwright-tests/tests/announcements.spec.js
@@ -25,6 +25,8 @@ test.describe("Don't ask again enabled", () => {
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
+    await page.getByRole("link", { name: "Announcements" }).click();
+
     const widgetSrc =
       "devhub.near/widget/devhub.entity.community.Announcements";
     await setDontAskAgainCacheValues({
@@ -188,6 +190,8 @@ test.describe("Admin wallet is connected", () => {
       "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
 
+    await page.getByRole("link", { name: "Announcements" }).click();
+
     const composeTextareaSelector = `textarea[data-testid="compose-announcement"]`;
     await page.waitForSelector(composeTextareaSelector, {
       state: "visible",
@@ -198,6 +202,9 @@ test.describe("Admin wallet is connected", () => {
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
+
+    await page.getByRole("link", { name: "Announcements" }).click();
+
     const composeTextareaSelector = `textarea[data-testid="compose-announcement"]`;
     // Wait for the compose area to be visible
     await page.waitForSelector(composeTextareaSelector, {
@@ -234,6 +241,9 @@ test.describe("Admin wallet is connected", () => {
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
+
+    await page.getByRole("link", { name: "Announcements" }).click();
+
     const commentButtonSelector = `button[title="Add Comment"]`;
     await page.waitForSelector(commentButtonSelector, {
       state: "visible",
@@ -244,6 +254,9 @@ test.describe("Admin wallet is connected", () => {
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
+
+    await page.getByRole("link", { name: "Announcements" }).click();
+
     const likeButtonSelector = `button[title="Like"]`;
     await page.waitForSelector(likeButtonSelector, {
       state: "visible",
@@ -254,6 +267,8 @@ test.describe("Admin wallet is connected", () => {
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic"
     );
+
+    await page.getByRole("link", { name: "Announcements" }).click();
 
     const posts_section = await page.locator(".card").nth(1);
     await posts_section.scrollIntoViewIfNeeded();

--- a/playwright-tests/tests/community.spec.js
+++ b/playwright-tests/tests/community.spec.js
@@ -188,8 +188,39 @@ test.describe("Is community admin", () => {
     await submitbutton.scrollIntoViewIfNeeded();
     await submitbutton.click();
 
+    const transactionText = JSON.stringify(
+      JSON.parse(await page.locator("div.modal-body code").innerText()),
+      null,
+      1
+    );
+    await pauseIfVideoRecording(page);
+    await expect(transactionText).toContain('"enabled_default_tabs": []');
+
     await pauseIfVideoRecording(page);
     await page.getByText("Close").click();
+
+    // toggle all tabs
+    await page.locator("#toggle-Announcements").click();
+    await page.locator("#toggle-Discussions").click();
+    await page.locator("#toggle-Activity").click();
+    await page.locator("#toggle-Teams").click();
+
+    await submitbutton.scrollIntoViewIfNeeded();
+    await submitbutton.click();
+
+    const transactionText2 = JSON.stringify(
+      JSON.parse(await page.locator("div.modal-body code").innerText()),
+      null,
+      1
+    );
+    await pauseIfVideoRecording(page);
+    await expect(transactionText2).toContain("Announcements");
+    await expect(transactionText2).toContain("Discussions");
+    await expect(transactionText2).toContain("Activity");
+    await expect(transactionText2).toContain("Teams");
+    await pauseIfVideoRecording(page);
+    await page.getByText("Close").click();
+
     await page.getByRole("button", { name: " Cancel" }).click();
   });
 });

--- a/playwright-tests/tests/community.spec.js
+++ b/playwright-tests/tests/community.spec.js
@@ -160,6 +160,38 @@ test.describe("Is community admin", () => {
       "WebAssembly Music is fantastic"
     );
   });
+
+  test("should be able to toggle default tabs section of a community", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/devhub.near/widget/app?page=community.configuration&handle=webassemblymusic"
+    );
+    await page.locator('h5:has-text("Default Tabs")').waitFor();
+    const editbutton = await page
+      .getByRole("button", { name: " Edit" })
+      .nth(4);
+    await editbutton.scrollIntoViewIfNeeded();
+    await editbutton.click();
+
+    await pauseIfVideoRecording(page);
+
+    // toggle all tabs
+    await page.locator("#toggle-Announcements").click();
+    await page.locator("#toggle-Discussions").click();
+    await page.locator("#toggle-Activity").click();
+    await page.locator("#toggle-Teams").click();
+
+    await pauseIfVideoRecording(page);
+
+    const submitbutton = await page.getByRole("button", { name: " Submit" });
+    await submitbutton.scrollIntoViewIfNeeded();
+    await submitbutton.click();
+
+    await pauseIfVideoRecording(page);
+    await page.getByText("Close").click();
+    await page.getByRole("button", { name: " Cancel" }).click();
+  });
 });
 
 test.describe("Is chain-abstraction community admin", () => {

--- a/src/core/adapter/devhub-contract.jsx
+++ b/src/core/adapter/devhub-contract.jsx
@@ -48,10 +48,16 @@ function getAccountCommunityPermissions({ account_id, community_handle }) {
 }
 
 function updateCommunity({ handle, community }) {
-  return Near.call("${REPL_DEVHUB_CONTRACT}", "update_community", {
-    handle,
-    community,
-  });
+  return Near.call(
+    "${REPL_DEVHUB_CONTRACT}",
+    "update_community",
+    {
+      handle,
+      community,
+    },
+    30000000000000, // gas (30Tgas)
+    0
+  );
 }
 
 function deleteCommunity({ handle }) {

--- a/src/devhub/entity/community/configuration/DefaultTabsConfigurator.jsx
+++ b/src/devhub/entity/community/configuration/DefaultTabsConfigurator.jsx
@@ -119,6 +119,7 @@ const TabItem = ({ data, onUpdate, onMove, index, isTop, isBottom }) => {
               value: data.enabled,
               onChange: handleEnableChange,
               disabled: !isActive,
+              key: data.title,
             }}
           />
         </div>

--- a/src/devhub/entity/community/configuration/DefaultTabsConfigurator.jsx
+++ b/src/devhub/entity/community/configuration/DefaultTabsConfigurator.jsx
@@ -1,0 +1,252 @@
+const { href } = VM.require("${REPL_DEVHUB}/widget/core.lib.url") || (() => {});
+
+const availableTabs = [
+  { title: "Announcements", enabled: true },
+  { title: "Discussions", enabled: true },
+  { title: "Activity", enabled: true },
+  { title: "Teams", enabled: true },
+];
+
+const isActive = props.isActive;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const Item = styled.div`
+  padding: 10px;
+  margin: 5px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Icon = styled.span`
+  margin-right: 10px;
+`;
+
+const EditableField = styled.input`
+  flex: 1;
+`;
+
+const ToggleButton = styled.input`
+  margin-left: 10px;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+`;
+
+const Header = styled.thead`
+  background-color: #f0f0f0;
+`;
+
+const HeaderCell = styled.th`
+  padding: 10px;
+  text-align: left;
+`;
+
+const Row = styled.tr``;
+
+const Cell = styled.td`
+  padding: 10px;
+`;
+
+const TabItem = ({ data, onUpdate, onMove, index, isTop, isBottom }) => {
+  const handleEnableChange = () => {
+    onUpdate({ ...data, enabled: !data.enabled });
+  };
+
+  const moveItemUp = () => {
+    if (!isTop) {
+      onMove(index, index - 1);
+    }
+  };
+
+  const moveItemDown = () => {
+    if (!isBottom) {
+      onMove(index, index + 1);
+    }
+  };
+
+  return (
+    <Row>
+      <Cell>
+        <div style={{ display: "flex", flexDirection: "column", gap: "0" }}>
+          <button
+            className="btn btn-sm btn-secondary rounded-0"
+            onClick={moveItemUp}
+            disabled={!isActive || isTop}
+            style={{ visibility: isTop && !isBottom ? "hidden" : "visible" }}
+          >
+            <i className="bi bi-arrow-up"></i>
+          </button>
+          <button
+            className="btn btn-sm btn-secondary rounded-0"
+            onClick={moveItemDown}
+            disabled={!isActive || isBottom}
+            style={{ visibility: isBottom && !isTop ? "hidden" : "visible" }}
+          >
+            <i className="bi bi-arrow-down"></i>
+          </button>
+        </div>
+      </Cell>
+      <Cell>
+        <Widget
+          src="${REPL_DEVHUB}/widget/devhub.components.molecule.Input"
+          props={{
+            label: " ",
+            value: data.title,
+            onChange: () => null,
+            inputProps: {
+              disabled: true,
+            },
+          }}
+        />
+      </Cell>
+      <Cell>
+        <div
+          className={
+            "d-flex flex-column flex-1 align-items-start justify-content-evenly"
+          }
+        >
+          <Widget
+            src={"${REPL_DEVHUB}/widget/devhub.components.atom.Toggle"}
+            props={{
+              value: data.enabled,
+              onChange: handleEnableChange,
+              disabled: !isActive,
+            }}
+          />
+        </div>
+      </Cell>
+    </Row>
+  );
+};
+
+function arraysAreEqual(arr1, arr2) {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const DefaultTabsConfigurator = ({ data, onSubmit }) => {
+  const initial = availableTabs.map((tab) =>
+    data.includes(tab.title)
+      ? { title: tab.title, enabled: true }
+      : { title: tab.title, enabled: false }
+  );
+
+  const orderedTabs = initial.slice().sort((a, b) => {
+    const indexA = data.indexOf(a.title);
+    const indexB = data.indexOf(b.title);
+
+    if (indexA !== -1 && indexB !== -1) {
+      return indexA - indexB;
+    }
+
+    if (indexA !== -1) {
+      return -1;
+    }
+    if (indexB !== -1) {
+      return 1;
+    }
+
+    return 0;
+  });
+
+  const [originalList, setOriginalList] = useState(orderedTabs);
+  const [list, setList] = useState(orderedTabs);
+  const [changesMade, setChangesMade] = useState(false);
+
+  useEffect(() => {
+    setOriginalList(orderedTabs);
+  }, [orderedTabs]);
+
+  // Enable or disable an item
+  const updateItem = (updatedItem) => {
+    const updatedList = list.map((item) =>
+      item.title === updatedItem.title ? updatedItem : item
+    );
+
+    setList(updatedList);
+    setChangesMade(!arraysAreEqual(originalList, updatedList));
+  };
+
+  const moveItem = (fromIndex, toIndex) => {
+    const updatedList = [...list];
+    const [movedItem] = updatedList.splice(fromIndex, 1);
+    updatedList.splice(toIndex, 0, movedItem);
+    setList(updatedList);
+    setChangesMade(!arraysAreEqual(originalList, updatedList));
+  };
+
+  return (
+    <Container>
+      <p>
+        Order or hide default tabs, which will appear in your community's
+        navigation bar.
+        <br />
+      </p>
+
+      <Table>
+        <Header>
+          <Row>
+            <HeaderCell style={{ width: "30px" }}>Order</HeaderCell>
+            <HeaderCell>Tab Name</HeaderCell>
+            <HeaderCell style={{ width: "45px" }}>Enabled</HeaderCell>
+          </Row>
+        </Header>
+        <tbody>
+          {list.map((item, index) => (
+            <TabItem
+              key={item}
+              data={item}
+              onUpdate={updateItem}
+              onMove={moveItem}
+              index={index}
+              isTop={index === 0}
+              isBottom={index === list.length - 1}
+            />
+          ))}
+        </tbody>
+      </Table>
+
+      {isActive && (
+        <div
+          className={"d-flex align-items-center justify-content-end gap-3 mt-4"}
+        >
+          <Widget
+            src={"${REPL_DEVHUB}/widget/devhub.components.molecule.Button"}
+            props={{
+              classNames: { root: "btn-success" },
+              disabled: !changesMade,
+              icon: {
+                type: "bootstrap_icon",
+                variant: "bi-check-circle-fill",
+              },
+              label: "Submit",
+              onClick: () =>
+                onSubmit(
+                  list
+                    .map((item) => (item.enabled ? item.title : null))
+                    .filter((item) => item !== null)
+                ),
+            }}
+          />
+        </div>
+      )}
+    </Container>
+  );
+};
+
+return DefaultTabsConfigurator(props);

--- a/src/devhub/page/community/configuration.jsx
+++ b/src/devhub/page/community/configuration.jsx
@@ -153,6 +153,35 @@ return (
         />
       </Tile>
     )}
+    {hasConfigurePermissions && (
+      <Tile className={"p-3 bg-white"}>
+        <Widget
+          src={
+            "${REPL_DEVHUB}/widget/devhub.entity.community.configuration.ConfigurationSection"
+          }
+          props={{
+            title: "Default Tabs",
+            hasConfigurePermissions,
+            Configurator: (p) => (
+              <Widget
+                src={
+                  "${REPL_DEVHUB}/widget/devhub.entity.community.configuration.DefaultTabsConfigurator"
+                }
+                props={{
+                  data: communityData.enabled_default_tabs || [],
+                  onSubmit: (v) =>
+                    updateCommunity({
+                      handle,
+                      community: { ...communityData, enabled_default_tabs: v },
+                    }),
+                  ...p,
+                }}
+              />
+            ),
+          }}
+        />
+      </Tile>
+    )}
     {hasDeletePermissions && (
       <div
         className="d-flex justify-content-center gap-4 p-4 w-100"

--- a/src/devhub/page/community/configuration.jsx
+++ b/src/devhub/page/community/configuration.jsx
@@ -168,7 +168,12 @@ return (
                   "${REPL_DEVHUB}/widget/devhub.entity.community.configuration.DefaultTabsConfigurator"
                 }
                 props={{
-                  data: communityData.enabled_default_tabs || [],
+                  data: communityData.enabled_default_tabs || [
+                    "Announcements",
+                    "Discussions",
+                    "Activity",
+                    "Teams",
+                  ],
                   onSubmit: (v) =>
                     updateCommunity({
                       handle,

--- a/src/devhub/page/community/configuration.jsx
+++ b/src/devhub/page/community/configuration.jsx
@@ -168,7 +168,7 @@ return (
                   "${REPL_DEVHUB}/widget/devhub.entity.community.configuration.DefaultTabsConfigurator"
                 }
                 props={{
-                  data: communityData.enabled_default_tabs || [
+                  data: communityData?.enabled_default_tabs || [
                     "Announcements",
                     "Discussions",
                     "Activity",

--- a/src/devhub/page/community/index.jsx
+++ b/src/devhub/page/community/index.jsx
@@ -47,10 +47,10 @@ if (!href) {
 }
 
 if (!tab) {
-  tab = community.enabled_default_tabs.length
-    ? community.enabled_default_tabs[0]
-    : community.addons.length
-    ? community.addons[0].display_name
+  tab = community?.enabled_default_tabs.length
+    ? community?.enabled_default_tabs[0]
+    : community?.addons.length
+    ? community?.addons[0].display_name
     : "Announcements";
 }
 
@@ -59,14 +59,18 @@ tab = normalize(tab);
 const [isLinkCopied, setLinkCopied] = useState(false);
 
 const unorderedTabs = [
-  community.enabled_default_tabs.includes("Announcements") && {
+  (community.enabled_default_tabs || ["Announcements"]).includes(
+    "Announcements"
+  ) && {
     title: "Announcements",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Announcements",
     params: {
       handle: community.handle,
     },
   },
-  community.enabled_default_tabs.includes("Discussions") && {
+  (community.enabled_default_tabs || ["Discussions"]).includes(
+    "Discussions"
+  ) && {
     title: "Discussions",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Discussions",
     params: {
@@ -74,14 +78,14 @@ const unorderedTabs = [
       transactionHashes: props.transactionHashes,
     },
   },
-  community.enabled_default_tabs.includes("Activity") && {
+  (community.enabled_default_tabs || ["Activity"]).includes("Activity") && {
     title: "Activity",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Activity",
     params: {
       handle: community.handle,
     },
   },
-  community.enabled_default_tabs.includes("Teams") && {
+  (community.enabled_default_tabs || ["Teams"]).includes("Teams") && {
     title: "Teams",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Teams",
     params: {

--- a/src/devhub/page/community/index.jsx
+++ b/src/devhub/page/community/index.jsx
@@ -47,22 +47,26 @@ if (!href) {
 }
 
 if (!tab) {
-  tab = "Announcements";
+  tab = community.enabled_default_tabs.length
+    ? community.enabled_default_tabs[0]
+    : community.addons.length
+    ? community.addons[0].display_name
+    : "Announcements";
 }
 
 tab = normalize(tab);
 
 const [isLinkCopied, setLinkCopied] = useState(false);
 
-const tabs = [
-  {
+const unorderedTabs = [
+  community.enabled_default_tabs.includes("Announcements") && {
     title: "Announcements",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Announcements",
     params: {
       handle: community.handle,
     },
   },
-  {
+  community.enabled_default_tabs.includes("Discussions") && {
     title: "Discussions",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Discussions",
     params: {
@@ -70,21 +74,39 @@ const tabs = [
       transactionHashes: props.transactionHashes,
     },
   },
-  {
+  community.enabled_default_tabs.includes("Activity") && {
     title: "Activity",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Activity",
     params: {
       handle: community.handle,
     },
   },
-  {
+  community.enabled_default_tabs.includes("Teams") && {
     title: "Teams",
     view: "${REPL_DEVHUB}/widget/devhub.entity.community.Teams",
     params: {
       handle: community.handle,
     },
   },
-];
+].filter((item) => item);
+
+const tabs = unorderedTabs.slice().sort((a, b) => {
+  const indexA = (community?.enabled_default_tabs || []).indexOf(a.title);
+  const indexB = (community?.enabled_default_tabs || []).indexOf(b.title);
+
+  if (indexA !== -1 && indexB !== -1) {
+    return indexA - indexB;
+  }
+
+  if (indexA !== -1) {
+    return -1;
+  }
+  if (indexB !== -1) {
+    return 1;
+  }
+
+  return 0;
+});
 
 (community.addons || []).map((addon) => {
   addon.enabled &&


### PR DESCRIPTION
_Resolves #709_

[Preview testnet](https://test.near.org/thomasguntenaar.testnet/widget/app?page=community&handle=test)
[Preview mainnet](https://near.org/geforcy.near/widget/app?page=communities) WIP deploying a community costs 4 NEAR which seems like a waist right now.

Acceptance criteria:
- [x] Add a "Default Tabs" section to the configure community page
- [x] Allow admin to enable or disable Announcements, Discussions, Activity, Teams
- [x] Add test


[video.webm](https://github.com/NEAR-DevHub/neardevhub-bos/assets/28901891/0729f396-2e9d-41e7-b208-8d8be7680536)
