### PR TITLE
Removing default tabs

### DIFF
--- a/playwright-tests/tests/addons.spec.js
+++ b/playwright-tests/tests/addons.spec.js
@@ -16,7 +16,7 @@ test.describe("Wallet is not connected", () => {
 
     // Try to find a button with the name ' Edit'
     const editButtons = await page.locator('button:has-text(" Edit")');
-    pauseIfVideoRecording(page);
+    await pauseIfVideoRecording(page);
     // Check that no such button exists
     expect(await editButtons.count()).toBe(0);
   });
@@ -154,6 +154,8 @@ test.describe("Wallet is connected", () => {
       // Add the blog addon in case there is 0
       await page.getByRole("combobox").selectOption("blog");
       await page.getByRole("button", { name: "" }).click();
+
+      const tbody = await page.getByTestId("addon-table");
 
       // Toggle the first addon
       const toggle = await tbody

--- a/playwright-tests/tests/addons.spec.js
+++ b/playwright-tests/tests/addons.spec.js
@@ -2,6 +2,16 @@ const { test, expect } = require("@playwright/test");
 import { pauseIfVideoRecording } from "../testUtils.js";
 import { mockDefaultTabs } from "../util/addons.js";
 
+test.beforeEach(async ({ page }) => {
+  await page.route("https://rpc.mainnet.near.org/", async (route) => {
+    await mockDefaultTabs(route);
+  });
+});
+
+test.afterEach(
+  async ({ page }) => await page.unrouteAll({ behavior: "ignoreErrors" })
+);
+
 test.describe("Wallet is not connected", () => {
   test.use({
     storageState: "playwright-tests/storage-states/wallet-not-connected.json",

--- a/playwright-tests/tests/addons.spec.js
+++ b/playwright-tests/tests/addons.spec.js
@@ -1,4 +1,26 @@
-const { test } = require("@playwright/test");
+const { test, expect } = require("@playwright/test");
+import { pauseIfVideoRecording } from "../testUtils.js";
+
+test.describe("Wallet is not connected", () => {
+  test.use({
+    storageState: "playwright-tests/storage-states/wallet-not-connected.json",
+  });
+
+  const baseUrl =
+    "/devhub.near/widget/app?page=community.configuration&handle=webassemblymusic";
+
+  test("should not find any buttons with the name ' Edit'", async ({
+    page,
+  }) => {
+    await page.goto(baseUrl);
+
+    // Try to find a button with the name ' Edit'
+    const editButtons = await page.locator('button:has-text(" Edit")');
+    pauseIfVideoRecording(page);
+    // Check that no such button exists
+    expect(await editButtons.count()).toBe(0);
+  });
+});
 
 test.describe("Wallet is connected", () => {
   test.use({
@@ -25,100 +47,132 @@ test.describe("Wallet is connected", () => {
         state: "visible",
       });
     });
+
+    test("Can add an addon to the list", async ({ page }) => {
+      await page.goto(baseUrl);
+
+      const editAddonButton = await page
+        .getByRole("button", { name: " Edit" })
+        .nth(3);
+      await editAddonButton.scrollIntoViewIfNeeded();
+      await editAddonButton.click();
+
+      await pauseIfVideoRecording(page);
+
+      const tbody = await page.getByTestId("addon-table");
+      const trs = await tbody.locator("tr");
+      const numberOfAddons = await trs.count();
+
+      await page.getByRole("combobox").selectOption("blog");
+
+      // Click on the plus
+      await page.getByRole("button", { name: "" }).click();
+
+      const trs2 = await tbody.locator("tr");
+
+      expect(await trs2.count()).toBe(numberOfAddons + 1);
+    });
+
+    test("Can reorder addons in the list", async ({ page }) => {
+      await page.goto(baseUrl);
+      const editAddonButton = await page
+        .getByRole("button", { name: " Edit" })
+        .nth(3);
+      await editAddonButton.scrollIntoViewIfNeeded();
+      await editAddonButton.click();
+
+      // Check if there is an addon
+      const tbody = await page.getByTestId("addon-table");
+
+      await page.getByRole("combobox").selectOption("blog");
+      await page.getByRole("button", { name: "" }).click();
+      await page.getByRole("combobox").selectOption("telegram");
+      await page.getByRole("button", { name: "" }).click();
+
+      // Get the initial order of addons
+      const initialOrder = await tbody
+        .locator("tr")
+        .evaluateAll((trs) => trs.map((tr) => tr.innerText));
+
+      await page
+        .getByRole("cell", { name: "", exact: true })
+        .getByRole("button")
+        .click();
+
+      // Get the order of addons after reordering
+      const newOrder = await tbody
+        .locator("tr")
+        .evaluateAll((trs) => trs.map((tr) => tr.innerText));
+      // Check that the order of addons has changed
+      expect(newOrder).not.toEqual(initialOrder);
+
+      await page
+        .getByRole("cell", { name: "", exact: true })
+        .getByRole("button")
+        .click();
+      const sameOrderAsInitial = await tbody
+        .locator("tr")
+        .evaluateAll((trs) => trs.map((tr) => tr.innerText));
+
+      expect(sameOrderAsInitial).toEqual(initialOrder);
+    });
+
+    test("Can remove an addon from the list", async ({ page }) => {
+      await page.goto(baseUrl);
+
+      const editAddonButton = await page
+        .getByRole("button", { name: " Edit" })
+        .nth(3);
+      await editAddonButton.scrollIntoViewIfNeeded();
+      await editAddonButton.click();
+
+      // Add the blog
+      await page.getByRole("combobox").selectOption("blog");
+      await page.getByRole("button", { name: "" }).click();
+
+      const tbody = await page.getByTestId("addon-table");
+      const trs = await tbody.locator("tr");
+      const numberOfAddons = await trs.count();
+
+      // Remove a blog
+      await page.locator("tr > td:nth-child(5) > div > .btn").first().click();
+
+      const numberOfAddons2 = await trs.count();
+
+      expect(numberOfAddons2).toBe(numberOfAddons - 1);
+    });
+
+    test("Can enable/disable an addon from the list", async ({ page }) => {
+      await page.goto(baseUrl);
+
+      const editAddonButton = await page
+        .getByRole("button", { name: " Edit" })
+        .nth(3);
+      await editAddonButton.scrollIntoViewIfNeeded();
+      await editAddonButton.click();
+
+      // Add the blog addon in case there is 0
+      await page.getByRole("combobox").selectOption("blog");
+      await page.getByRole("button", { name: "" }).click();
+
+      // Toggle the first addon
+      const toggle = await tbody
+        .getByRole("row")
+        .first()
+        .getByRole("cell")
+        .nth(3)
+        .locator("#toggle-");
+      const textbox = await tbody
+        .getByRole("row")
+        .first()
+        .getByRole("cell")
+        .nth(2)
+        .getByRole("textbox");
+
+      expect(textbox).toBeEnabled();
+      await toggle.click();
+
+      expect(textbox).toBeDisabled();
+    });
   });
 });
-
-// NOTE:
-// The below tests need some more work.
-// We are using the DIG component, which is essentially a Radix Select field.
-// Radix select renders as an input and requires to be focused, then value inputted, before the option can be selected.
-// I was having trouble making this work.
-
-//     test('Can add an addon to the list', async ({ page }) => {
-//         await page.goto(baseUrl);
-
-//         await page.click(dropdownSelector);
-//         await page.fill(dropdownSelector, 'Wiki');
-//         await page.click(`li:has-text('Wiki')`);
-
-//         await page.waitForSelector(addButtonSelector, {
-//           state: "visible",
-//         });
-
-//         await page.click(addButtonSelector);
-
-//         const addedAddon = await page.$('input[type="text"].form-control[disabled][value="Wiki"]'); // You will need to fill this in
-//         expect(addedAddon).toBeTruthy();
-//     });
-
-//     test('Can reorder addons in the list', async ({ page }) => {
-//         await page.goto(baseUrl);
-
-//         await page.click(dropdownSelector);
-//         await page.inputValue(dropdownSelector, 'Wiki');
-//         await page.click(`li:has-text('Wiki')`);
-
-//         await page.waitForSelector(addButtonSelector, {
-//           state: "visible",
-//         });
-
-//         await page.click(addButtonSelector);
-
-//         await page.inputValue(dropdownSelector, 'telegram');
-//         await page.click(addButtonSelector);
-
-//         await page.waitForSelector(moveUpButtonSelector, {
-//           state: "visible",
-//         });
-
-//         await page.click(moveUpButtonSelector);
-
-//         const firstAddon = await page.$('input[type="text"].form-control[disabled][value="Telegram"]');
-//         const secondAddon = await page.$('input[type="text"].form-control[disabled][value="Wiki"]');
-//         expect(firstAddon).toBeTruthy();
-//         expect(secondAddon).toBeTruthy();
-//     });
-
-//     test('Can remove an addon from the list', async ({ page }) => {
-//         await page.goto(baseUrl);
-
-//         await page.inputValue(dropdownSelector, 'Wiki');
-
-//         await page.waitForSelector(addButtonSelector, {
-//           state: "visible",
-//         });
-
-//         await page.click(addButtonSelector);
-
-//         await page.waitForSelector(removeButtonSelector, {
-//           state: "visible",
-//         });
-
-//         await page.click(removeButtonSelector);
-
-//         const removedAddon = await page.$('input[type="text"].form-control[disabled][value="Wiki"]'); // You will need to fill this in
-//         expect(removedAddon).toBeNull();
-//     });
-
-//     test('Can toggle to disable an addon', async ({ page }) => {
-//         await page.goto(baseUrl);
-
-//         await page.inputValue(dropdownSelector, 'Wiki');
-//         await page.waitForSelector(addButtonSelector, {
-//           state: "visible",
-//         });
-
-//         await page.click(addButtonSelector);
-
-//         await page.waitForSelector(toggleButtonSelector, {
-//           state: "visible",
-//         });
-
-//         await page.click(toggleButtonSelector);
-
-//         const toggleState = await page.getAttribute(toggleButtonSelector, 'aria-checked');
-//         expect(toggleState).toBe('false');
-//     });
-// });
-
-// });

--- a/playwright-tests/tests/community.spec.js
+++ b/playwright-tests/tests/community.spec.js
@@ -1,58 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { pauseIfVideoRecording } from "../testUtils.js";
-
-import { decodeResultJSON, encodeResultJSON } from "../util/transaction.js";
-
-async function mockActivityPage(page) {
-  await page.route("https://rpc.mainnet.near.org/", async (route) => {
-    const request = await route.request();
-    const requestPostData = request.postDataJSON();
-
-    if (
-      requestPostData.params &&
-      requestPostData.params.account_id === "devhub.near" &&
-      requestPostData.params.method_name === "get_community" &&
-      atob(requestPostData.params.args_base64).includes("handle")
-    ) {
-      const response = await route.fetch();
-      const json = await response.json();
-
-      const resultObj = decodeResultJSON(json.result.result);
-
-      resultObj.addons = [
-        ...resultObj.addons,
-        {
-          id: "9yhcct",
-          addon_id: "announcements",
-          display_name: "Announcements",
-          enabled: true,
-          parameters: "{}",
-        },
-        {
-          addon_id: "discussions",
-          display_name: "Discussions",
-          enabled: true,
-          id: "gqyrw7",
-          parameters: "{}",
-        },
-        {
-          addon_id: "activity",
-          display_name: "Activity",
-          enabled: true,
-          id: "bqyrw6",
-          parameters: "{}",
-        },
-      ];
-
-      json.result.result = encodeResultJSON(resultObj);
-
-      await route.fulfill({ response, json });
-      return;
-    } else {
-      await route.continue();
-    }
-  });
-}
+import { mockDefaultTabs } from "../util/addons.js";
 
 test("should load a community page if handle exists", async ({ page }) => {
   await page.goto(
@@ -97,7 +45,9 @@ test.describe("Wallet is connected", () => {
   test("should allow connected user to post from community page", async ({
     page,
   }) => {
-    await mockActivityPage(page);
+    await page.route("https://rpc.mainnet.near.org/", async (route) => {
+      await mockDefaultTabs(route);
+    });
     test.setTimeout(60000);
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=activity"

--- a/playwright-tests/tests/discussions.spec.js
+++ b/playwright-tests/tests/discussions.spec.js
@@ -11,85 +11,13 @@ import {
   decodeResultJSON,
   encodeResultJSON,
 } from "../util/transaction.js";
+import { mockDefaultTabs } from "../util/addons.js";
 import { mockSocialIndexResponses } from "../util/socialapi.js";
 
-async function mockDiscussionTab(page) {
-  await page.route("https://rpc.mainnet.near.org/", async (route) => {
-    const request = await route.request();
-    const requestPostData = request.postDataJSON();
-
-    const devComponents = (
-      await fetch("http://localhost:3030").then((r) => r.json())
-    ).components;
-
-    if (
-      requestPostData.params &&
-      requestPostData.params.account_id === "social.near" &&
-      requestPostData.params.method_name === "get"
-    ) {
-      const social_get_key = JSON.parse(
-        atob(requestPostData.params.args_base64)
-      ).keys[0];
-
-      const response = await route.fetch({
-        url: "https://rpc.mainnet.near.org/",
-      });
-      const json = await response.json();
-
-      if (devComponents[social_get_key]) {
-        const social_get_key_parts = social_get_key.split("/");
-        const devWidget = {};
-        devWidget[social_get_key_parts[0]] = { widget: {} };
-        devWidget[social_get_key_parts[0]].widget[social_get_key_parts[2]] =
-          devComponents[social_get_key].code;
-        json.result.result = Array.from(
-          new TextEncoder().encode(JSON.stringify(devWidget))
-        );
-      }
-      await route.fulfill({ response, json });
-    } else if (requestPostData.method === "tx") {
-      await route.continue({ url: "https://archival-rpc.mainnet.near.org/" });
-      // await route.continue({ url: "https://1rpc.io/near" });
-    } else if (
-      requestPostData.params &&
-      requestPostData.params.account_id === "devhub.near" &&
-      requestPostData.params.method_name === "get_community"
-    ) {
-      const response = await route.fetch();
-      const json = await response.json();
-
-      const resultObj = decodeResultJSON(json.result.result);
-
-      resultObj.addons = [
-        ...resultObj.addons,
-        {
-          id: "9yhcct",
-          addon_id: "announcements",
-          display_name: "Announcements",
-          enabled: true,
-          parameters: "{}",
-        },
-        {
-          addon_id: "discussions",
-          display_name: "Discussions",
-          enabled: true,
-          id: "gqyrw7",
-          parameters: "{}",
-        },
-      ];
-
-      json.result.result = encodeResultJSON(resultObj);
-
-      await route.fulfill({ response, json });
-      return;
-    } else {
-      await route.continue();
-    }
-  });
-}
-
 test.beforeEach(async ({ page }) => {
-  await mockDiscussionTab(page);
+  await page.route("https://rpc.mainnet.near.org/", async (route) => {
+    await mockDefaultTabs(route);
+  });
 });
 
 test.afterEach(

--- a/playwright-tests/tests/discussions.spec.js
+++ b/playwright-tests/tests/discussions.spec.js
@@ -13,6 +13,85 @@ import {
 } from "../util/transaction.js";
 import { mockSocialIndexResponses } from "../util/socialapi.js";
 
+async function mockDiscussionTab(page) {
+  await page.route("https://rpc.mainnet.near.org/", async (route) => {
+    const request = await route.request();
+    const requestPostData = request.postDataJSON();
+
+    const devComponents = (
+      await fetch("http://localhost:3030").then((r) => r.json())
+    ).components;
+
+    if (
+      requestPostData.params &&
+      requestPostData.params.account_id === "social.near" &&
+      requestPostData.params.method_name === "get"
+    ) {
+      const social_get_key = JSON.parse(
+        atob(requestPostData.params.args_base64)
+      ).keys[0];
+
+      const response = await route.fetch({
+        url: "https://rpc.mainnet.near.org/",
+      });
+      const json = await response.json();
+
+      if (devComponents[social_get_key]) {
+        const social_get_key_parts = social_get_key.split("/");
+        const devWidget = {};
+        devWidget[social_get_key_parts[0]] = { widget: {} };
+        devWidget[social_get_key_parts[0]].widget[social_get_key_parts[2]] =
+          devComponents[social_get_key].code;
+        json.result.result = Array.from(
+          new TextEncoder().encode(JSON.stringify(devWidget))
+        );
+      }
+      await route.fulfill({ response, json });
+    } else if (requestPostData.method === "tx") {
+      await route.continue({ url: "https://archival-rpc.mainnet.near.org/" });
+      // await route.continue({ url: "https://1rpc.io/near" });
+    } else if (
+      requestPostData.params &&
+      requestPostData.params.account_id === "devhub.near" &&
+      requestPostData.params.method_name === "get_community"
+    ) {
+      const response = await route.fetch();
+      const json = await response.json();
+
+      const resultObj = decodeResultJSON(json.result.result);
+
+      resultObj.addons = [
+        ...resultObj.addons,
+        {
+          id: "9yhcct",
+          addon_id: "announcements",
+          display_name: "Announcements",
+          enabled: true,
+          parameters: "{}",
+        },
+        {
+          addon_id: "discussions",
+          display_name: "Discussions",
+          enabled: true,
+          id: "gqyrw7",
+          parameters: "{}",
+        },
+      ];
+
+      json.result.result = encodeResultJSON(resultObj);
+
+      await route.fulfill({ response, json });
+      return;
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockDiscussionTab(page);
+});
+
 test.afterEach(
   async ({ page }) => await page.unrouteAll({ behavior: "ignoreErrors" })
 );
@@ -65,16 +144,6 @@ test.describe("Wallet is connected", () => {
     await discussionPostEditor.fill(socialdbpostcontent.text);
 
     await page.getByTestId("post-btn").click();
-    await page.route("https://rpc.mainnet.near.org/", async (route) => {
-      const request = await route.request();
-
-      const requestPostData = request.postDataJSON();
-      if (requestPostData.method === "tx") {
-        await route.continue({ url: "https://1rpc.io/near" });
-      } else {
-        await route.continue();
-      }
-    });
 
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions&transactionHashes=mi2a1KwagRFZhpqBNKhKaCTkHVj98J8tZnxSr1NpxSQ"
@@ -144,16 +213,6 @@ test.describe("Wallet is connected", () => {
 
     await page.getByTestId("post-btn").click();
 
-    await page.route("https://rpc.mainnet.near.org/", async (route) => {
-      const request = await route.request();
-
-      const requestPostData = request.postDataJSON();
-      if (requestPostData.method === "tx") {
-        await route.continue({ url: "https://archival-rpc.mainnet.near.org/" });
-      } else {
-        await route.continue();
-      }
-    });
     await page.goto(
       "/devhub.near/widget/app?page=community&handle=webassemblymusic&tab=discussions&transactionHashes=mi2a1KwagRFZhpqBNKhKaCTkHVj98J8tZnxSr1NpxSQ"
     );
@@ -174,10 +233,6 @@ test.describe("Don't ask again enabled", () => {
     "discussions.webassemblymusic.community.devhub.near";
 
   test("should create a discussion", async ({ page }) => {
-    await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
-      page
-    );
-
     let discussion_created = false;
     await mockSocialIndexResponses(page, ({ requestPostData, json }) => {
       if (
@@ -276,6 +331,42 @@ test.describe("Don't ask again enabled", () => {
 
               discussion_created = true;
             }
+            await route.fulfill({ response, json });
+            return;
+          } else if (postData.method === "tx") {
+            await route.continue({
+              url: "https://archival-rpc.mainnet.near.org/",
+            });
+          } else if (
+            postData.params &&
+            postData.params.account_id === "devhub.near" &&
+            postData.params.method_name === "get_community"
+          ) {
+            const response = await route.fetch();
+            const json = await response.json();
+
+            const resultObj = decodeResultJSON(json.result.result);
+
+            resultObj.addons = [
+              ...resultObj.addons,
+              {
+                id: "9yhcct",
+                addon_id: "announcements",
+                display_name: "Announcements",
+                enabled: true,
+                parameters: "{}",
+              },
+              {
+                addon_id: "discussions",
+                display_name: "Discussions",
+                enabled: true,
+                id: "gqyrw7",
+                parameters: "{}",
+              },
+            ];
+
+            json.result.result = encodeResultJSON(resultObj);
+
             await route.fulfill({ response, json });
             return;
           }

--- a/playwright-tests/util/addons.js
+++ b/playwright-tests/util/addons.js
@@ -1,0 +1,89 @@
+import { decodeResultJSON, encodeResultJSON } from "./transaction.js";
+
+export async function mockDefaultTabs(route) {
+  const request = await route.request();
+  const requestPostData = request.postDataJSON();
+
+  const devComponents = (
+    await fetch("http://localhost:3030").then((r) => r.json())
+  ).components;
+
+  if (
+    requestPostData.params &&
+    requestPostData.params.account_id === "social.near" &&
+    requestPostData.params.method_name === "get"
+  ) {
+    const social_get_key = JSON.parse(atob(requestPostData.params.args_base64))
+      .keys[0];
+
+    const response = await route.fetch({
+      url: "https://rpc.mainnet.near.org/",
+    });
+    const json = await response.json();
+
+    // Replace component with local component
+    if (devComponents[social_get_key]) {
+      const social_get_key_parts = social_get_key.split("/");
+      const devWidget = {};
+      devWidget[social_get_key_parts[0]] = { widget: {} };
+      devWidget[social_get_key_parts[0]].widget[social_get_key_parts[2]] =
+        devComponents[social_get_key].code;
+      json.result.result = Array.from(
+        new TextEncoder().encode(JSON.stringify(devWidget))
+      );
+    }
+    await route.fulfill({ response, json });
+  } else if (requestPostData.method === "tx") {
+    await route.continue({ url: "https://archival-rpc.mainnet.near.org/" });
+  } else if (
+    requestPostData.params &&
+    requestPostData.params.account_id === "devhub.near" &&
+    requestPostData.params.method_name === "get_community" &&
+    atob(requestPostData.params.args_base64).includes("handle")
+  ) {
+    // Add default tabs to community
+    const response = await route.fetch();
+    const json = await response.json();
+
+    const resultObj = decodeResultJSON(json.result.result);
+
+    resultObj.addons = [
+      ...resultObj.addons,
+      {
+        id: "9yhcct",
+        addon_id: "announcements",
+        display_name: "Announcements",
+        enabled: true,
+        parameters: "{}",
+      },
+      {
+        addon_id: "discussions",
+        display_name: "Discussions",
+        enabled: true,
+        id: "gqyrw7",
+        parameters: "{}",
+      },
+      {
+        addon_id: "activity",
+        display_name: "Activity",
+        enabled: true,
+        id: "bqyrw6",
+        parameters: "{}",
+      },
+      {
+        addon_id: "teams",
+        display_name: "Teams",
+        enabled: true,
+        id: "cqyrw8",
+        parameters: "{}",
+      },
+    ];
+
+    json.result.result = encodeResultJSON(resultObj);
+
+    await route.fulfill({ response, json });
+    return;
+  } else {
+    await route.continue();
+  }
+}

--- a/scripts/migrate_tabs_addons.sh
+++ b/scripts/migrate_tabs_addons.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+# Define the contract and account
+CONTRACT="devhub.near"
+# !! Define the account that will sign the transactions
+ACCOUNT="thomasguntenaar.near"
+
+# Define the list of community handles
+# !! uncomment: COMMUNITY_HANDLES="nft hot-ideas protocol contract-standards tooling wallet validators zero-knowledge akaia dao challenges build hacks keypom refi ndc owa developer-dao near-discovery component-libraries documentation harmonic devhub-platform fellowship devrel near-campus devhub-marketing near-enterprise ariz-portfolio nearukraine near-thailand onboard security webassemblymusic she-is-near data neardevnews chain-abstraction"
+COMMUNITY_HANDLES="webassemblymusic"
+
+# Iterate through each community handle
+for HANDLE in $COMMUNITY_HANDLES; do
+    # Fetch current community data
+    COMMUNITY_DATA=$(near contract call-function as-read-only $CONTRACT get_community json-args "{\"handle\": \"$HANDLE\"}" network-config mainnet now)
+    
+     # Check if fetching community data was successful
+    if [ $? -ne 0 ]; then
+        echo "Failed to fetch data for community: $HANDLE"
+        continue
+    fi
+
+    # Extract current addons from community data using jq
+    CURRENT_ADDONS=$(echo $COMMUNITY_DATA | jq -c '.addons')
+    
+    # Prepare the list of new addons, including the required ones
+    NEW_ADDONS=$(jq -c --argjson current_addons "$CURRENT_ADDONS" '[
+        {
+            "id": "announcements",
+            "addon_id": "announcements",
+            "display_name": "Announcements",
+            "enabled": true,
+            "parameters": "{}"
+        },
+        {
+            "id": "discussions",
+            "addon_id": "discussions",
+            "display_name": "Discussions",
+            "enabled": true,
+            "parameters": "{}"
+        },
+        {
+            "id": "activity",
+            "addon_id": "activity",
+            "display_name": "Activity",
+            "enabled": true,
+            "parameters": "{}"
+        }
+    ] + $current_addons' <<<"$CURRENT_ADDONS")
+
+    echo $NEW_ADDONS;
+
+    # Call the set_community_addons function with the new addons
+    near contract call-function as-transaction $CONTRACT set_community_addons json-args "{\"handle\": \"$HANDLE\", \"addons\": $NEW_ADDONS}" prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as $ACCOUNT network-config mainnet sign-with-keychain send
+    
+    # Check the result of the transaction
+    if [ $? -eq 0 ]; then
+        echo "Successfully set addons for community: $HANDLE"
+    else
+        echo "Failed to set addons for community: $HANDLE"
+    fi
+done

--- a/src/devhub/entity/community/Activity.jsx
+++ b/src/devhub/entity/community/Activity.jsx
@@ -3,10 +3,16 @@ const { handle } = props;
 const { getCommunity } = VM.require(
   "${REPL_DEVHUB}/widget/core.adapter.devhub-contract"
 );
-
 const { href } = VM.require("${REPL_DEVHUB}/widget/core.lib.url");
 
-if (!getCommunity || !href) {
+getCommunity = getCommunity || (() => <></>);
+href || (href = () => {});
+
+if (!handle) {
+  return <p>Handle not defined</p>;
+}
+
+if (!href) {
   return <p>Loading modules...</p>;
 }
 

--- a/src/devhub/entity/community/configuration/AddonsConfigurator.jsx
+++ b/src/devhub/entity/community/configuration/AddonsConfigurator.jsx
@@ -250,7 +250,7 @@ const AddonsConfigurator = ({ data, onSubmit }) => {
               <HeaderCell style={{ width: "40px" }}>Actions</HeaderCell>
             </Row>
           </Header>
-          <tbody>
+          <tbody data-testid="addon-table">
             {list.map((item, index) => (
               <AddonItem
                 key={item.id}

--- a/src/devhub/page/addon.jsx
+++ b/src/devhub/page/addon.jsx
@@ -103,7 +103,7 @@ if ("${REPL_DEVHUB}" !== "devhub.near") {
 
 return (
   <Container>
-    {permissions.can_configure && (
+    {permissions.can_configure && addonMatch.configurator_widget !== "" && (
       <SettingsButton
         onClick={() => setView(view === "configure" ? "view" : "configure")}
       >

--- a/src/devhub/page/addon.jsx
+++ b/src/devhub/page/addon.jsx
@@ -142,6 +142,7 @@ return (
             data: config,
             handle,
             permissions,
+            transactionHashes: props.transactionHashes,
           }}
         />
       )}

--- a/src/devhub/page/community/index.jsx
+++ b/src/devhub/page/community/index.jsx
@@ -61,7 +61,11 @@ const tabs = [];
     tabs.push({
       title: addon.display_name,
       view: "${REPL_DEVHUB}/widget/devhub.page.addon",
-      params: { addon, handle: community.handle },
+      params: {
+        addon,
+        handle: community.handle,
+        transactionHashes: props.transactionHashes,
+      },
     });
 });
 

--- a/src/devhub/page/community/index.jsx
+++ b/src/devhub/page/community/index.jsx
@@ -54,44 +54,14 @@ tab = normalize(tab);
 
 const [isLinkCopied, setLinkCopied] = useState(false);
 
-const tabs = [
-  {
-    title: "Announcements",
-    view: "${REPL_DEVHUB}/widget/devhub.entity.community.Announcements",
-    params: {
-      handle: community.handle,
-    },
-  },
-  {
-    title: "Discussions",
-    view: "${REPL_DEVHUB}/widget/devhub.entity.community.Discussions",
-    params: {
-      handle: community.handle,
-      transactionHashes: props.transactionHashes,
-    },
-  },
-  {
-    title: "Activity",
-    view: "${REPL_DEVHUB}/widget/devhub.entity.community.Activity",
-    params: {
-      handle: community.handle,
-    },
-  },
-  {
-    title: "Teams",
-    view: "${REPL_DEVHUB}/widget/devhub.entity.community.Teams",
-    params: {
-      handle: community.handle,
-    },
-  },
-];
+const tabs = [];
 
 (community.addons || []).map((addon) => {
   addon.enabled &&
     tabs.push({
       title: addon.display_name,
       view: "${REPL_DEVHUB}/widget/devhub.page.addon",
-      params: { addon },
+      params: { addon, handle: community.handle },
     });
 });
 
@@ -135,7 +105,7 @@ function trimHttps(url) {
   return url;
 }
 
-// some communties have url as handle (eg: devhub platform) while others has correct handle
+// some communities have url as handle (eg: devhub platform) while others has correct handle
 function checkTelegramHandle(tg) {
   const pattern = /https:\/\/t.me\/(.*)/;
   const includesHttp = tg.match(pattern);


### PR DESCRIPTION
_Resolves #709_
_Resolves #587_

This PR removes the default tabs. First these things need to happen:

- [x] A moderator in the devhub.near contract calls `create_addon` 4 times to add the addons. (I will add the arguments below)
- [x] The communities we use in tests need to either enable these addons or we need to mock that the addons are enabled. 
- [x] The announcement discussions activity and teams tab tests need to be re-run and succeed 
- [x] Create a script to enable the addons on all communities
- [x] Execute the script @frol and merge
- [ ] Merge

[Testnet preview](https://test.near.org/thomasguntenaar.testnet/widget/app?page=community&handle=test)