### PR TITLE
Edit proposal timeline with "don't ask again" enabled

### DIFF
--- a/playwright-tests/storage-states/wallet-connected-with-devhub-moderator-access-key.json
+++ b/playwright-tests/storage-states/wallet-connected-with-devhub-moderator-access-key.json
@@ -1,0 +1,51 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:8080",
+      "localStorage": [
+        {
+          "name": "near-wallet-selector:selectedWalletId",
+          "value": "\"my-near-wallet\""
+        },
+        {
+          "name": "near_app_wallet_auth_key",
+          "value": "{\"accountId\":\"theori.near\",\"allKeys\":[\"ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi\"]}"
+        },
+        {
+          "name": "devgovgigs.near_wallet_auth_key",
+          "value": "{\"accountId\":\"theori.near\",\"allKeys\":[\"ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi\"]}"
+        },
+        {
+          "name": "devhub.near_wallet_auth_key",
+          "value": "{\"accountId\":\"theori.near\",\"allKeys\":[\"ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi\"]}"
+        },
+        {
+          "name": "near-api-js:keystore:theori.near:mainnet",
+          "value": "ed25519:67p9ygtfVNZz5AzMkeN4bqstCck8RWxWDthcTa7JaBvxkrBRTc6A43SsuPy9LdtiR6XtSRD1HiS4KQTWCZw83FKS"
+        },
+        {
+          "name": "devgovgigs.near:keystore:theori.near:mainnet",
+          "value": "ed25519:4SViyksDtdDdCPkkyzMg4HYADEQ3t5YGEd3EBoSADxdaAzDasZ7qJbxr2wNSFkWipya6C2eVJJucK1vkyoGndiyt"
+        },
+        {
+          "name": "devhub.near:keystore:theori.near:mainnet",
+          "value": "ed25519:eUVkG7dVfg5Z776MPy7d4L23cmEtAxrYoP1HgWSQrBy1GHdaZystRkYyz4ANN5uyKceuUrjyoLWaPgpzvo3BNDZ"
+        },
+        {
+          "name": "near-social-vm:v01::accountId:",
+          "value": "\"theori.near\""
+        },
+        {
+          "name": "near-wallet-selector:recentlySignedInWallets",
+          "value": "[\"my-near-wallet\"]"
+        },
+        {
+          "name": "near-wallet-selector:contract",
+          "value": "{\"contractId\":\"social.near\",\"methodNames\":[]}"
+        }
+      ]
+    }
+  ],
+  "sessionStorage": []
+}

--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -322,6 +322,11 @@ test.describe('Moderator with "Don\'t ask again" enabled', () => {
       "moved proposal from REVIEW to APPROVED"
     );
     await lastLogItem.scrollIntoViewIfNeeded();
+    const timeLineStatusSubmittedToast = await page.getByText(
+      "Timeline status submitted"
+    );
+    await expect(timeLineStatusSubmittedToast).toBeVisible();
+    await expect(timeLineStatusSubmittedToast).not.toBeAttached();
     await pauseIfVideoRecording(page);
   });
 });

--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -308,7 +308,13 @@ test.describe('Moderator with "Don\'t ask again" enabled', () => {
     await page.locator(".d-flex > div > .bi").click();
     await page.getByRole("button", { name: "Review", exact: true }).click();
     await page.getByText("Approved", { exact: true }).first().click();
+
+    await pauseIfVideoRecording(page);
+
+    const saveButton = await page.getByRole("button", { name: "Save" });
+    await saveButton.scrollIntoViewIfNeeded();
     await page.getByRole("button", { name: "Save" }).click();
+
     const callContractToast = await page.getByText("Sending transaction");
     await expect(callContractToast).toBeVisible();
     await expect(callContractToast).not.toBeAttached();

--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -245,6 +245,7 @@ test.describe('Moderator with "Don\'t ask again" enabled', () => {
       "playwright-tests/storage-states/wallet-connected-with-devhub-moderator-access-key.json",
   });
   test("should edit proposal timeline", async ({ page }) => {
+    test.setTimeout(60000);
     let isTransactionCompleted = false;
 
     await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
@@ -311,6 +312,11 @@ test.describe('Moderator with "Don\'t ask again" enabled', () => {
     const callContractToast = await page.getByText("Sending transaction");
     await expect(callContractToast).toBeVisible();
     await expect(callContractToast).not.toBeAttached();
+    const timeLineStatusSubmittedToast = await page.getByText(
+      "Timeline status submitted"
+    );
+    await expect(timeLineStatusSubmittedToast).toBeVisible();
+
     await expect(firstStatusBadge).toHaveText("APPROVED");
     await firstStatusBadge.scrollIntoViewIfNeeded();
     await pauseIfVideoRecording(page);
@@ -322,10 +328,6 @@ test.describe('Moderator with "Don\'t ask again" enabled', () => {
       "moved proposal from REVIEW to APPROVED"
     );
     await lastLogItem.scrollIntoViewIfNeeded();
-    const timeLineStatusSubmittedToast = await page.getByText(
-      "Timeline status submitted"
-    );
-    await expect(timeLineStatusSubmittedToast).toBeVisible();
     await expect(timeLineStatusSubmittedToast).not.toBeAttached();
     await pauseIfVideoRecording(page);
   });

--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -258,9 +258,24 @@ test.describe('Moderator with "Don\'t ask again" enabled', () => {
       },
     });
 
+    await mockTransactionSubmitRPCResponses(
+      page,
+      async ({
+        route,
+        request,
+        transaction_completed,
+        last_receiver_id,
+        requestPostData,
+      }) => {
+        console.log("RPC mock", requestPostData);
+        await route.fallback();
+      }
+    );
+
     await page.goto("/devhub.near/widget/app?page=proposal&id=17");
     await setDontAskAgainCacheValues({
       page,
+      contractId: "devhub.near",
       widgetSrc: "devhub.near/widget/devhub.entity.proposal.Proposal",
       methodName: "edit_proposal_timeline",
     });
@@ -269,7 +284,9 @@ test.describe('Moderator with "Don\'t ask again" enabled', () => {
     await page.getByRole("button", { name: "Review", exact: true }).click();
     await page.getByText("Approved", { exact: true }).first().click();
     await page.getByRole("button", { name: "Save" }).click();
-    await page.waitForTimeout(5000);
+    const callContractToast = await page.getByText("Sending transaction");
+    await expect(callContractToast).toBeVisible();
+    await expect(callContractToast).not.toBeAttached();
   });
 });
 

--- a/playwright-tests/util/rpcmock.js
+++ b/playwright-tests/util/rpcmock.js
@@ -1,0 +1,46 @@
+export const MOCK_RPC_URL = "https://rpc.mainnet.near.org";
+
+export async function mockRpcRequest({
+  page,
+  filterParams = {},
+  mockedResult = {},
+  modifyOriginalResultFunction = null,
+}) {
+  await page.route(MOCK_RPC_URL, async (route, request) => {
+    const postData = request.postDataJSON();
+
+    const filterParamsKeys = Object.keys(filterParams);
+    if (
+      filterParamsKeys.filter(
+        (param) => postData.params[param] === filterParams[param]
+      ).length === filterParamsKeys.length
+    ) {
+      const json = await route.fetch().then((r) => r.json());
+
+      if (modifyOriginalResultFunction) {
+        const originalResult = JSON.parse(
+          new TextDecoder().decode(new Uint8Array(json.result.result))
+        );
+        mockedResult = await modifyOriginalResultFunction(originalResult);
+      }
+
+      const mockedResponse = {
+        jsonrpc: "2.0",
+        id: "dontcare",
+        result: {
+          result: Array.from(
+            new TextEncoder().encode(JSON.stringify(mockedResult))
+          ),
+        },
+      };
+
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockedResponse),
+      });
+    } else {
+      route.fallback();
+    }
+  });
+}

--- a/playwright-tests/util/transaction.js
+++ b/playwright-tests/util/transaction.js
@@ -157,6 +157,7 @@ export async function mockTransactionSubmitRPCResponses(page, customhandler) {
         request,
         transaction_completed,
         last_receiver_id,
+        requestPostData,
       });
     } else {
       await route.continue();

--- a/src/devhub/entity/proposal/CommentsAndLogs.jsx
+++ b/src/devhub/entity/proposal/CommentsAndLogs.jsx
@@ -78,12 +78,13 @@ State.init({
   data: null,
   socialComments: null,
   changedKeysListWithValues: null,
+  snapshotHistoryLength: 0,
 });
 
 function sortTimelineAndComments() {
   const comments = Social.index("comment", props.item, { subscribe: true });
 
-  if (state.changedKeysListWithValues === null) {
+  if (snapshotHistory.length > state.snapshotHistoryLength) {
     const changedKeysListWithValues = snapshotHistory
       .slice(1)
       .map((item, index) => {
@@ -93,7 +94,10 @@ function sortTimelineAndComments() {
           ...getDifferentKeysWithValues(startingPoint, item),
         };
       });
-    State.update({ changedKeysListWithValues });
+    State.update({
+      changedKeysListWithValues,
+      snapshotHistoryLength: snapshotHistory.length,
+    });
   }
 
   // sort comments and timeline logs by time

--- a/src/devhub/entity/proposal/Proposal.jsx
+++ b/src/devhub/entity/proposal/Proposal.jsx
@@ -525,10 +525,15 @@ const editProposalStatus = ({ timeline }) => {
       gas: 270000000000000,
     },
   ]);
+  setEditProposalTimelineCalled(true);
 };
 
 const [isReviewModalOpen, setReviewModal] = useState(false);
 const [isCancelModalOpen, setCancelModal] = useState(false);
+const [isEditProposalTimelineCalled, setEditProposalTimelineCalled] =
+  useState(false);
+const [showTimeLineStatusSubmittedToast, setShowTimeLineStatusSubmittedToast] =
+  useState(false);
 const [showTimelineSetting, setShowTimelineSetting] = useState(false);
 const proposalStatus = useCallback(
   () =>
@@ -540,6 +545,10 @@ const proposalStatus = useCallback(
 const [updatedProposalStatus, setUpdatedProposalStatus] = useState({});
 
 useEffect(() => {
+  if (isEditProposalTimelineCalled) {
+    setShowTimeLineStatusSubmittedToast(true);
+    setEditProposalTimelineCalled(false);
+  }
   setUpdatedProposalStatus({
     ...proposalStatus(),
     value: { ...proposalStatus().value, ...snapshot.timeline },
@@ -616,6 +625,17 @@ const createdDate =
 
 return (
   <Container className="d-flex flex-column gap-2 w-100 mt-4">
+    <Widget
+      src="near/widget/DIG.Toast"
+      props={{
+        title: "Timeline status submitted successfully",
+        type: "success",
+        open: showTimeLineStatusSubmittedToast,
+        onOpenChange: (v) => setShowTimeLineStatusSubmittedToast(v),
+        trigger: <></>,
+        providerProps: { duration: 3000 },
+      }}
+    />
     <Widget
       src={"${REPL_DEVHUB}/widget/devhub.entity.proposal.ConfirmReviewModal"}
       props={{


### PR DESCRIPTION
- add test case for approving a proposal with don't ask again enabled
- update log without having to refresh after saving changed timeline status
- confirmation toast when editing timeline update transaction is finished

https://github.com/NEAR-DevHub/neardevhub-bos/assets/9760441/f57b70d7-bdca-437b-a177-b27aefc54b44


fixes #800 