### PR TITLE
Fix text overflow of linked proposals

### DIFF
--- a/src/devhub/entity/proposal/Proposal.jsx
+++ b/src/devhub/entity/proposal/Proposal.jsx
@@ -424,9 +424,11 @@ const LinkedProposals = () => {
                 }}
               />
               <div className="d-flex flex-column" style={{ maxWidth: 250 }}>
-                <LinkProfile account={item.snapshot.name}>
-                  <b className="text-truncate">{item.snapshot.name}</b>
-                </LinkProfile>
+                <div className="text-truncate">
+                  <LinkProfile account={item.snapshot.name}>
+                    <b>{item.snapshot.name}</b>
+                  </LinkProfile>
+                </div>
                 <div className="text-sm text-muted">
                   created on {readableDate(item.snapshot.timestamp / 1000000)}
                 </div>


### PR DESCRIPTION
Resolves #813 
Note: It's already fixed for IC.
<img width="1512" alt="image" src="https://github.com/NEAR-DevHub/neardevhub-bos/assets/100185149/41e412b1-260e-46be-93cd-ada898997039">
