### PR TITLE
Feature/746 relevant mentions

### DIFF
--- a/instances/devhub.near/widget/devhub/components/molecule/Compose.jsx
+++ b/instances/devhub.near/widget/devhub/components/molecule/Compose.jsx
@@ -29,6 +29,7 @@ const Compose = ({
   showProposalIdAutoComplete,
   onChangeKeyup,
   handler,
+  sortedRelevantUsers,
 }) => {
   State.init({
     data: data,
@@ -97,6 +98,7 @@ const Compose = ({
                 showProposalIdAutoComplete: showProposalIdAutoComplete,
                 autoFocus: state.autoFocus,
                 onChangeKeyup: onChangeKeyup,
+                sortedRelevantUsers,
               }}
             />
           </>

--- a/instances/devhub.near/widget/devhub/components/molecule/SimpleMDE.jsx
+++ b/instances/devhub.near/widget/devhub/components/molecule/SimpleMDE.jsx
@@ -11,6 +11,7 @@ const onChangeKeyup = props.onChangeKeyup ?? (() => {}); // in case where we wan
 const height = props.height ?? "390";
 const className = props.className ?? "w-100";
 const embeddCSS = props.embeddCSS;
+const sortedRelevantUsers = props.sortedRelevantUsers || [];
 
 State.init({
   iframeHeight: height,
@@ -136,10 +137,12 @@ let showAccountAutoComplete = ${showAccountAutoComplete};
 let showProposalIdAutoComplete = ${showProposalIdAutoComplete};
 
 function getSuggestedAccounts(term) {
-  let results = [];
+  let results = [${sortedRelevantUsers
+    .map((u) => "{accountId:'" + u + "', score: 100}")
+    .join(",")}];
 
   term = (term || "").replace(/\W/g, "").toLowerCase();
-  const limit = 5;
+  const limit = ${5 + sortedRelevantUsers.length};
 
   const profiles = Object.entries(profilesData);
 

--- a/instances/devhub.near/widget/devhub/entity/proposal/ComposeComment.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/ComposeComment.jsx
@@ -206,6 +206,7 @@ const Compose = useMemo(() => {
         embeddCSS: ComposeEmbeddCSS,
         handler: handler,
         showProposalIdAutoComplete: true,
+        sortedRelevantUsers: props.sortedRelevantUsers,
       }}
     />
   );

--- a/instances/devhub.near/widget/devhub/entity/proposal/Proposal.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/Proposal.jsx
@@ -294,6 +294,11 @@ const item = {
   path: `${REPL_DEVHUB_CONTRACT}/post/main`,
   blockHeight,
 };
+const comments = Social.index("comment", item) ?? [];
+const commentAuthors = [
+  ...new Set(comments.map((comment) => comment.accountId)),
+];
+
 const proposalURL = getLinkUsingCurrentGateway(
   `${REPL_DEVHUB}/widget/app?page=proposal&id=${proposal.id}&timestamp=${snapshot.timestamp}`
 );
@@ -916,6 +921,12 @@ return (
                     item: item,
                     notifyAccountId: authorId,
                     id: proposal.id,
+                    sortedRelevantUsers: [
+                      authorId,
+                      snapshot.supervisor,
+                      snapshot.requested_sponsor,
+                      ...commentAuthors,
+                    ],
                   }}
                 />
               </div>

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -456,6 +456,58 @@ test.describe("Wallet is connected", () => {
     await pauseIfVideoRecording(page);
   });
 
+  test("should show relevant users in mention autocomplete", async ({
+    page,
+  }) => {
+    await page.goto("/devhub.near/widget/app?page=proposal&id=112");
+
+    await page.waitForSelector(`iframe`, {
+      state: "visible",
+    });
+
+    const smt = page.getByRole("link", { name: "geforcy.near" });
+    await smt.waitFor();
+
+    const heading = page.getByRole("heading", { name: "Relevant Mentions" });
+    await heading.waitFor();
+
+    await page.waitForTimeout(5000);
+
+    const delay_milliseconds_between_keypress_when_typing = 0;
+    const commentEditor = page
+      .frameLocator("iframe")
+      .locator(".CodeMirror textarea");
+    await commentEditor.focus();
+    await commentEditor.pressSequentially(
+      `Make sure relevant users show up in a mention. @`,
+      {
+        delay: delay_milliseconds_between_keypress_when_typing,
+      }
+    );
+
+    await pauseIfVideoRecording(page);
+    const iframe = page.frameLocator("iframe");
+    const liFrameLocators = iframe.frameLocator(
+      'ul[id="mentiondropdown"] > li'
+    );
+    const liLocators = await liFrameLocators.owner().all();
+    const expected = [
+      "thomasguntenaar.near", // author,
+      "theori.near", // supervisor,
+      "neardevdao.near", //  requested_sponsor,
+      // "geforcy.near", // comment author,
+    ];
+    let mentionSuggestions = [];
+    for (let i = 0; i < liLocators.length; i++) {
+      const text = await liLocators[i].innerText();
+      mentionSuggestions.push(text);
+    }
+    // TODO should be 0,4 including geforcy.near but somehow mob.near shows up.
+    // When I manually test, it shows the correct 4 users
+    expect(mentionSuggestions.slice(0, 3)).toEqual(expected);
+    await pauseIfVideoRecording(page);
+  });
+
   test("should show only valid input in amount field and show error for invalid", async ({
     page,
   }) => {


### PR DESCRIPTION
_Resolves #746_

@ori-near I've added the supervisor and requested sponsor as relevant users to the acceptance criteria. The last ac will never happen since there will always be an author and sponsor. There is currently a limit of 5 users + any relevant users that are suggested when a users types `@`. I could add a scroll in the suggestion box if you want to show all devhub users.

PS Instead of all devhub users we could show all proposal authors? This is a list that is available via a contract call. Are there more users we count as devhub users but won't be included in this list.

Acceptance Criteria:
 - [x] When a user types "@" while composing a comment on a proposal, the dropdown prioritizes users relevant to the discussion
   - [x] First: The proposal's author
   - [x] Second supervisor
   - [x] Third requested sponsor
   - [x] Fourth: Users who have recently commented on the proposal
 - [ ] If there are no relevant users (e.g. the user is the first comment), the dropdown displays all DevHub users in alphabetical order

<img width="771" alt="Screenshot 2024-06-19 at 12 21 07" src="https://github.com/NEAR-DevHub/neardevhub-bos/assets/28901891/07acc59f-2d48-4832-95c2-5e6380eb2435">
<img width="794" alt="Screenshot 2024-06-19 at 12 21 16" src="https://github.com/NEAR-DevHub/neardevhub-bos/assets/28901891/ea9b59e8-3de2-4467-a13b-ce27a4fe3307">


[video.webm](https://github.com/NEAR-DevHub/neardevhub-bos/assets/28901891/9d1ebc99-c5f5-4f29-911e-9b38aad51afc)

