### PR TITLE
share link button for copying url, share proposal with clean URL

### DIFF
--- a/instances/devhub.near/widget/devhub/components/molecule/ShareLinkButton.jsx
+++ b/instances/devhub.near/widget/devhub/components/molecule/ShareLinkButton.jsx
@@ -1,4 +1,12 @@
+const postType = props.postType ?? "post";
 const externalLink = props.url;
+
+const clickbaitPrompt =
+  props.clickbaitPrompt ??
+  `Check out this ${postType} on @NEARProtocol\n#NEAR #BOS\n${externalLink}`;
+
+const xUrl = new URL("https://x.com/intent/post");
+xUrl.searchParams.set("text", clickbaitPrompt);
 
 const Button = styled.button`
   border: 0;
@@ -76,14 +84,24 @@ return (
 
     <DropdownMenu sideOffset={5}>
       <ul>
-        <Widget
-          src="mob.near/widget/CopyButton"
-          props={{
-            text: externalLink,
-            className: "btn btn-outline-dark dropdown-item",
-            label: `Copy link to ${postType}`,
-          }}
-        />
+        <li>
+          <Widget
+            src="mob.near/widget/CopyButton"
+            props={{
+              text: externalLink,
+              className: "btn btn-outline-dark dropdown-item",
+              label: `Copy link to ${postType}`,
+            }}
+          />
+        </li>
+        <li>
+          <Popover.Close asChild>
+            <a href={xUrl.toString()} target="_blank">
+              <i className="bi bi-x" />
+              Share on X
+            </a>
+          </Popover.Close>
+        </li>
       </ul>
 
       <Popover.Arrow style={{ fill: "#fff" }} />

--- a/instances/devhub.near/widget/devhub/components/molecule/ShareLinkButton.jsx
+++ b/instances/devhub.near/widget/devhub/components/molecule/ShareLinkButton.jsx
@@ -1,0 +1,92 @@
+const externalLink = props.url;
+
+const Button = styled.button`
+  border: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #687076;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 17px;
+  cursor: pointer;
+  background: none;
+  padding: 6px;
+  transition: color 200ms;
+
+  i {
+    font-size: 18px;
+    transition: color 200ms;
+  }
+
+  &:hover,
+  &:focus {
+    outline: none;
+    color: #11181c;
+  }
+`;
+
+const DropdownMenu = styled("Popover.Content")`
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 0 40px rgba(0, 0, 0, 0.15);
+  z-index: 10000;
+  padding: 0.5rem;
+  outline: none;
+
+  ul {
+    list-style: none;
+    display: block;
+    margin: 0;
+    padding: 0;
+  }
+
+  li {
+    display: block;
+  }
+
+  a {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.5rem;
+    font: var(--text-base);
+    color: var(--sand12);
+    outline: none;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  i {
+    color: var(--violet8);
+  }
+`;
+
+return (
+  <Popover.Root>
+    <Popover.Trigger asChild>
+      <Button type="button" title="Share">
+        <i className="bi bi-share" />
+      </Button>
+    </Popover.Trigger>
+
+    <DropdownMenu sideOffset={5}>
+      <ul>
+        <Widget
+          src="mob.near/widget/CopyButton"
+          props={{
+            text: externalLink,
+            className: "btn btn-outline-dark dropdown-item",
+            label: `Copy link to ${postType}`,
+          }}
+        />
+      </ul>
+
+      <Popover.Arrow style={{ fill: "#fff" }} />
+    </DropdownMenu>
+  </Popover.Root>
+);

--- a/instances/devhub.near/widget/devhub/entity/proposal/Proposal.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/Proposal.jsx
@@ -681,7 +681,7 @@ return (
         <Widget
           src="${REPL_DEVHUB}/widget/devhub.components.molecule.ShareLinkButton"
           props={{
-            postType: "post",
+            postType: "proposal",
             url: proposalURL,
           }}
         />

--- a/instances/devhub.near/widget/devhub/entity/proposal/Proposal.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/Proposal.jsx
@@ -300,9 +300,7 @@ const commentAuthors = [
   ...new Set(comments.map((comment) => comment.accountId)),
 ];
 
-const proposalURL = getLinkUsingCurrentGateway(
-  `${REPL_DEVHUB}/widget/app?page=proposal&id=${proposal.id}&timestamp=${snapshot.timestamp}`
-);
+const proposalURL = `https://${REPL_DEVHUB}.page/proposal/${proposal.id}`;
 
 const KycVerificationStatus = () => {
   const isVerified = true;
@@ -681,7 +679,7 @@ return (
       </div>
       <div className="d-flex gap-2 align-items-center">
         <Widget
-          src="${REPL_NEAR}/widget/ShareButton"
+          src="${REPL_DEVHUB}/widget/devhub.components.molecule.ShareLinkButton"
           props={{
             postType: "post",
             url: proposalURL,

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -239,6 +239,15 @@ test.describe("Don't ask again enabled", () => {
     await pauseIfVideoRecording(page);
   });
 });
+test("share button should create a clean URL link", async ({ page }) => {
+  await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
+    page
+  );
+  await page.goto("/devhub.near/widget/app?page=proposal&id=17");
+  const widgetSrc = "devhub.near/widget/devhub.entity.proposal.ComposeComment";
+
+  await page.pause();
+});
 test.describe('Moderator with "Don\'t ask again" enabled', () => {
   test.use({
     storageState:

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -698,15 +698,12 @@ test.describe("share links", () => {
     },
   });
   test("copy link button should create a clean URL link", async ({ page }) => {
-    await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
-      page
-    );
     await page.goto("/devhub.near/widget/app?page=proposal&id=127");
 
     await expect(await page.getByText("#127")).toBeVisible();
     const shareLinkButton = await page.getByRole("button", { name: "" });
     await shareLinkButton.click();
-    await page.getByRole("button", { name: "Copy link to" }).click();
+    await page.getByRole("button", { name: "Copy link to proposal" }).click();
 
     const linkUrlFromClipboard = await page.evaluate(
       "navigator.clipboard.readText()"
@@ -726,9 +723,6 @@ test.describe("share links", () => {
     page,
     context,
   }) => {
-    await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
-      page
-    );
     await page.goto("/devhub.near/widget/app?page=proposal&id=127");
 
     await expect(await page.getByText("#127")).toBeVisible();
@@ -737,7 +731,7 @@ test.describe("share links", () => {
     const shareOnXLink = await page.getByRole("link", { name: " Share on X" });
     const shareOnXUrl = await shareOnXLink.getAttribute("href");
     await expect(shareOnXUrl).toEqual(
-      "https://x.com/intent/post?text=Check+out+this+post+on+%40NEARProtocol%0A%23NEAR+%23BOS%0Ahttps%3A%2F%2Fdevhub.near.page%2Fproposal%2F127"
+      "https://x.com/intent/post?text=Check+out+this+proposal+on+%40NEARProtocol%0A%23NEAR+%23BOS%0Ahttps%3A%2F%2Fdevhub.near.page%2Fproposal%2F127"
     );
     await shareOnXLink.click();
     const twitterPage = await context.waitForEvent("page");

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -697,7 +697,7 @@ test.describe("share links", () => {
       permissions: ["clipboard-read", "clipboard-write"],
     },
   });
-  test("share button should create a clean URL link", async ({
+  test("copy link button should create a clean URL link", async ({
     page,
     context,
   }) => {
@@ -723,5 +723,27 @@ test.describe("share links", () => {
     await expect(await newTab.getByText("#127")).toBeVisible({
       timeout: 10000,
     });
+  });
+
+  test("share on X should create a clean URL link", async ({
+    page,
+    context,
+  }) => {
+    await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
+      page
+    );
+    await page.goto("/devhub.near/widget/app?page=proposal&id=127");
+
+    await expect(await page.getByText("#127")).toBeVisible();
+    const shareLinkButton = await page.getByRole("button", { name: "" });
+    await shareLinkButton.click();
+    const shareOnXLink = await page.getByRole("link", { name: " Share on X" });
+    const shareOnXUrl = await shareOnXLink.getAttribute("href");
+    await expect(shareOnXUrl).toEqual(
+      "https://x.com/intent/post?text=Check+out+this+post+on+%40NEARProtocol%0A%23NEAR+%23BOS%0Ahttps%3A%2F%2Fdevhub.near.page%2Fproposal%2F127"
+    );
+    await shareOnXLink.click();
+    const twitterPage = await context.waitForEvent("page");
+    await twitterPage.waitForURL(shareOnXUrl);
   });
 });

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -697,10 +697,7 @@ test.describe("share links", () => {
       permissions: ["clipboard-read", "clipboard-write"],
     },
   });
-  test("copy link button should create a clean URL link", async ({
-    page,
-    context,
-  }) => {
+  test("copy link button should create a clean URL link", async ({ page }) => {
     await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
       page
     );
@@ -717,10 +714,10 @@ test.describe("share links", () => {
     expect(linkUrlFromClipboard).toEqual(
       "https://devhub.near.page/proposal/127"
     );
-    const newTab = await context.newPage();
-    newTab.goto(linkUrlFromClipboard);
+    await pauseIfVideoRecording(page);
+    await page.goto(linkUrlFromClipboard);
 
-    await expect(await newTab.getByText("#127")).toBeVisible({
+    await expect(await page.getByText("#127")).toBeVisible({
       timeout: 10000,
     });
   });

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -239,15 +239,7 @@ test.describe("Don't ask again enabled", () => {
     await pauseIfVideoRecording(page);
   });
 });
-test("share button should create a clean URL link", async ({ page }) => {
-  await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
-    page
-  );
-  await page.goto("/devhub.near/widget/app?page=proposal&id=17");
-  const widgetSrc = "devhub.near/widget/devhub.entity.proposal.ComposeComment";
 
-  await page.pause();
-});
 test.describe('Moderator with "Don\'t ask again" enabled', () => {
   test.use({
     storageState:
@@ -696,5 +688,40 @@ test.describe("Wallet is connected", () => {
     await input.press("Enter");
     const element = page.locator(`:has-text("${term}")`).nth(1);
     await expect(element).toBeVisible();
+  });
+});
+
+test.describe("share links", () => {
+  test.use({
+    contextOptions: {
+      permissions: ["clipboard-read", "clipboard-write"],
+    },
+  });
+  test("share button should create a clean URL link", async ({
+    page,
+    context,
+  }) => {
+    await modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader(
+      page
+    );
+    await page.goto("/devhub.near/widget/app?page=proposal&id=127");
+
+    await expect(await page.getByText("#127")).toBeVisible();
+    const shareLinkButton = await page.getByRole("button", { name: "" });
+    await shareLinkButton.click();
+    await page.getByRole("button", { name: "Copy link to" }).click();
+
+    const linkUrlFromClipboard = await page.evaluate(
+      "navigator.clipboard.readText()"
+    );
+    expect(linkUrlFromClipboard).toEqual(
+      "https://devhub.near.page/proposal/127"
+    );
+    const newTab = await context.newPage();
+    newTab.goto(linkUrlFromClipboard);
+
+    await expect(await newTab.getByText("#127")).toBeVisible({
+      timeout: 10000,
+    });
   });
 });

--- a/scripts/dev-gateway.mjs
+++ b/scripts/dev-gateway.mjs
@@ -5,9 +5,8 @@ import { homedir, tmpdir } from 'os';
 import { readFile, writeFile, cp } from 'fs/promises';
 import { rpcProxy } from './rpc-cache-proxy.mjs';
 
-await rpcProxy();
-
 const instanceName = process.argv[process.argv.length - 1];
+await rpcProxy(instanceName);
 const instanceFolder = `instances/${instanceName}`;
 
 const statingWebHostinFolder = tmpdir()+'/bos'+new Date().toJSON().replace(/[^0-9]/g,'');


### PR DESCRIPTION
- add a share link button for copying url
- share proposal using the new share link button with a clean URL ( e.g. https://devhub.near.page/proposal/22 )
- add test for "Share to X" button
- Remove share to Email button
-  Get local widgets from bos loader via the local RPC proxy, so that there is no need to use a redirect-map with the VM anymore. Also since redirect maps does not works with "don't ask again", this approach eliminates the need for using `modifySocialNearGetRPCResponsesInsteadOfGettingWidgetsFromBOSLoader` in "don't ask again" tests ( since this is now moved to the RPC proxy ). 

https://github.com/NEAR-DevHub/neardevhub-bos/assets/9760441/55de1155-2029-4154-a8b8-56cbeb736b6a



fixes #851