### PR TITLE
Show latest developer-dao blogs

### DIFF
--- a/instances/devhub.near/widget/devhub/components/organism/Navbar.jsx
+++ b/instances/devhub.near/widget/devhub/components/organism/Navbar.jsx
@@ -153,7 +153,7 @@ let links = [
     title: "/about",
     links: [
       { title: "mission", href: "about" },
-      { title: "blog", href: "blog" },
+      { title: "blog", href: "blogv2" },
       { title: "newsletter", href: "https://newsletter.neardevhub.org" },
       {
         title: "calendar",

--- a/instances/devhub.near/widget/devhub/entity/addon/blogv2/Viewer.jsx
+++ b/instances/devhub.near/widget/devhub/entity/addon/blogv2/Viewer.jsx
@@ -150,7 +150,7 @@ const categories = {
   },
 };
 
-function flattenBlogObject(blogsObject) {
+function publishedBlogsOfThisInstance(blogsObject) {
   if (!blogsObject) return [];
   return (
     Object.keys(blogsObject)
@@ -165,6 +165,13 @@ function flattenBlogObject(blogsObject) {
       .filter((blog) => blog.status === "PUBLISH")
       // Every instance of the blog tab has its own blogs
       .filter((blog) => blog.communityAddonId === communityAddonId)
+  );
+}
+
+function flattenBlogObject(blogsObject) {
+  if (!blogsObject) return [];
+  return (
+    publishedBlogsOfThisInstance(blogsObject)
       // Add categories to the dropdown
       .map((flattenedBlog) => {
         if (!categories[flattenedBlog.category]) {
@@ -195,6 +202,7 @@ function flattenBlogObject(blogsObject) {
       )
   );
 }
+
 function checkHashes() {
   if (transactionHashes) {
     // Fetch new blog data
@@ -232,6 +240,7 @@ useEffect(() => {
   checkHashes();
 }, []);
 
+const publishedBlogs = publishedBlogsOfThisInstance(blogData);
 const processedData = flattenBlogObject(blogData)
   // Sort by published date
   .sort((blog1, blog2) => {
@@ -327,7 +336,7 @@ const categoryInput = useMemo(() => {
   );
 }, [categories]);
 
-if (!processedData || processedData.length === 0) {
+if (!publishedBlogs || publishedBlogs.length === 0) {
   return (
     <div
       className="d-flex flex-column align-items-center justify-content-center gap-4"

--- a/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/provider.jsx
+++ b/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/provider.jsx
@@ -29,6 +29,24 @@ useEffect(() => {
   }
 }, [initialBlogData]);
 
+function publishedBlogsOfThisInstance(blogsObject) {
+  if (!blogsObject) return [];
+  return (
+    Object.keys(blogsObject)
+      .map((key) => {
+        return {
+          ...blogsObject[key].metadata,
+          id: key,
+          content: blogsObject[key][""],
+        };
+      })
+      // Show only published blogs
+      .filter((blog) => blog.status === "PUBLISH")
+      // Every instance of the blog tab has its own blogs
+      .filter((blog) => blog.communityAddonId === communityAddonId)
+  );
+}
+
 function checkHashes() {
   if (transactionHashes) {
     // Fetch new blog data
@@ -43,8 +61,8 @@ function checkHashes() {
           const newBlogPosts = result[`${handle}.community.devhub.near`].blog;
           // Check the number of blogs in this instance with a different status
           if (
-            flattenBlogObject(newBlogPosts).length !==
-            flattenBlogObject(blogData).length
+            publishedBlogsOfThisInstance(newBlogPosts).length !==
+            publishedBlogsOfThisInstance(blogData).length
           ) {
             setBlogData(newBlogPosts);
           } else {

--- a/instances/devhub.near/widget/devhub/page/blogv2.jsx
+++ b/instances/devhub.near/widget/devhub/page/blogv2.jsx
@@ -137,8 +137,9 @@ return (
       <Widget
         src={"${REPL_DEVHUB}/widget/devhub.entity.addon.blogv2.Viewer"}
         props={{
-          handle: community,
+          handle: "developer-dao",
           hideTitle: true,
+          communityAddonId: "blogv2",
         }}
       />
     </BlogContainer>


### PR DESCRIPTION
This PR fixes the following:

- Ori pointed out that the blog link in the navigation bar still pointed to blog v1 instead of v2.
- Blogv2 page was still showing this `blog isn't configured yet` because no communityAddonId was being passed. 
- The provider referenced a function that wasn't defined in that file.

All these bugs are fixed with this PR.