### PR TITLE
Remove conditional styled component from blogv2

### DIFF
--- a/instances/devhub.near/widget/devhub/entity/addon/blogv2/Card.jsx
+++ b/instances/devhub.near/widget/devhub/entity/addon/blogv2/Card.jsx
@@ -36,23 +36,25 @@ function Card({ data, addonParameters }) {
       line-height: 110%; /* 39.6px */
     }
 
-    ${category &&
-    `
+    span.news {
+      color: #f40303;
+    }
+
+    span.reference {
+      color: #ff7a00;
+    }
+
+    span.guide {
+      color: #004be1;
+    }
+
     span.category {
-      color: ${
-        category.toLowerCase() === "news"
-          ? "#F40303"
-          : category.toLowerCase() === "guide"
-          ? "#004BE1"
-          : category.toLowerCase() === "reference" && "#FF7A00"
-      };
       font-size: 1rem;
       font-style: normal;
       font-weight: 700;
       line-height: 20px; /* 125% */
       text-transform: uppercase;
     }
-    `}
 
     span.date {
       color: #818181;
@@ -81,7 +83,10 @@ function Card({ data, addonParameters }) {
       {category &&
         categoriesEnabled === "enabled" &&
         categoryIsOptionInSettings && (
-          <span className="category" data-testid="card-category">
+          <span
+            className={`category ${category && category.toLowerCase()}`}
+            data-testid="card-category"
+          >
             {category}
           </span>
         )}

--- a/instances/devhub.near/widget/devhub/entity/addon/blogv2/Page.jsx
+++ b/instances/devhub.near/widget/devhub/entity/addon/blogv2/Page.jsx
@@ -32,23 +32,26 @@ const Container = styled.div`
   padding: 0 3rem;
   margin-bottom: 2rem;
   position: relative;
-  ${category &&
-  `
-    span.category {
-      color: ${
-        category.toLowerCase() === "news"
-          ? "#F40303"
-          : category.toLowerCase() === "guide"
-          ? "#004BE1"
-          : category.toLowerCase() === "reference" && "#FF7A00"
-      };
-      font-size: 1.5rem;
-      font-style: normal;
-      font-weight: 700;
-      line-height: 20px; /* 125% */
-      text-transform: uppercase;
-    }
-    `}
+
+  span.news {
+    color: #f40303;
+  }
+
+  span.reference {
+    color: #ff7a00;
+  }
+
+  span.guide {
+    color: #004be1;
+  }
+
+  span.category {
+    font-size: 1.5rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 20px; /* 125% */
+    text-transform: uppercase;
+  }
 
   div.date {
     color: #818181;
@@ -175,7 +178,10 @@ return (
       {category &&
         parameters.categoriesEnabled === "enabled" &&
         categoryIsOptionInSettings && (
-          <span className="category" data-testid="blog-category">
+          <span
+            className={`category ${category && category.toLowerCase()}`}
+            data-testid="blog-category"
+          >
             {category}
           </span>
         )}


### PR DESCRIPTION
As @petersalomonsen mentioned [here](https://t.me/c/1822948693/1/6602). The tests flash a `VM is dead` message because of condionally styled components. 

This PR:
- Removed these conditions from the `styled` components and moved it into a class based on the category.
- Fixed the VM is dead flash.
- This should also improve the blogv2 test suite