### PR TITLE
Show categories blog page

### DIFF
--- a/instances/devhub.near/widget/devhub/page/blogv2.jsx
+++ b/instances/devhub.near/widget/devhub/page/blogv2.jsx
@@ -1,9 +1,10 @@
 const { id, community } = props;
 
-const { getAccountCommunityPermissions } = VM.require(
+const { getAccountCommunityPermissions, getCommunity } = VM.require(
   "${REPL_DEVHUB}/widget/core.adapter.devhub-contract"
 ) || {
   getAccountCommunityPermissions: () => {},
+  getCommunity: () => {},
 };
 
 const [showEditScreenData, setShowEditScreen] = useState(null);
@@ -127,6 +128,13 @@ if (showEditScreenData) {
     </EditorContainer>
   );
 }
+
+const communityObject = getCommunity({ handle: "developer-dao" });
+const blogv2 = (communityObject.addons || []).find(
+  (addon) => addon.id === "blogv2"
+);
+const config = JSON.parse(blogv2.parameters || {}) || {};
+
 return (
   <div className="w-100">
     <Widget src={`${REPL_DEVHUB}/widget/devhub.components.island.banner`} />
@@ -140,6 +148,7 @@ return (
           handle: "developer-dao",
           hideTitle: true,
           communityAddonId: "blogv2",
+          data: config,
         }}
       />
     </BlogContainer>

--- a/instances/devhub.near/widget/devhub/page/community/index.jsx
+++ b/instances/devhub.near/widget/devhub/page/community/index.jsx
@@ -56,31 +56,6 @@ const [isLinkCopied, setLinkCopied] = useState(false);
 
 const [addonView, setAddonView] = useState("viewer");
 
-// CommunityAddOn
-const blogv2 = {
-  addon_id: "blogv2",
-  display_name: "BlogV2",
-  enabled: true,
-  id: "blogv2",
-  parameters:
-    '{"title":"My blog page title",\
-     "subtitle":"Classic subtitle",\
-     "auhtorEnabled": "enabled",\
-     "searchEnabled": "enabled",\
-     "orderBy": "timedesc",\
-     "categoriesEnabled": "enabled",\
-     "categories": ["news", "guide", "reference"],\
-     "categoryRequired": false}',
-};
-
-const blogv2instance2 = {
-  addon_id: "blogv2",
-  display_name: "BlogV2",
-  enabled: true,
-  id: "blogv2instance2",
-  parameters: "{}",
-};
-
 const tabs = [];
 
 (community.addons || []).map((addon) => {


### PR DESCRIPTION
If you go to [the blog page](https://near.social/devhub.near/widget/app?page=blogv2) the categories are hidden.


This PR:
- Displays the right categories
- Add categorie filter
- Removes some dead code