### PR TITLE
Fixes bug: blog submit button alignment in UI

### DIFF
--- a/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/content.jsx
+++ b/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/content.jsx
@@ -634,7 +634,9 @@ return (
                   }}
                 />
               </>
-            ) : null}
+            ) : (
+              <div></div>
+            )}
             <div className="flex gap-x-3 align-items-center">
               <Widget
                 src={`${REPL_DEVHUB}/widget/devhub.components.molecule.Button`}


### PR DESCRIPTION
## The issue
The submit button of the blog editor wasn't aligned on the right when a user created a new blog. Only when the blog already existed. 

## The fix
Align the button on the right with flex (justify-between).

As you can see here it is now on the right again:

<img width="964" alt="Screenshot 2024-07-16 at 03 36 23" src="https://github.com/user-attachments/assets/54650e69-1ed4-4b2b-a0fa-b13e3a00c0be">
