### PR TITLE
Fix Bug: blog title won't submit with weird characters

### DIFF
--- a/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/provider.jsx
+++ b/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/provider.jsx
@@ -116,7 +116,7 @@ function transformString(str) {
   const transformedStr = lowerCaseStr.replace(/ /g, "-");
 
   // Replace anything that is not a letter or a number with an empty string
-  const cleanedStr = transformedStr.replace(/[^a-z0-9A-Z]/g, "");
+  const cleanedStr = transformedStr.replace(/[^a-z0-9A-Z-]/g, "");
 
   // Return the transformed string
   return cleanedStr;

--- a/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/provider.jsx
+++ b/instances/devhub.near/widget/devhub/entity/addon/blogv2/editor/provider.jsx
@@ -115,8 +115,11 @@ function transformString(str) {
   // Replace spaces with hyphens
   const transformedStr = lowerCaseStr.replace(/ /g, "-");
 
+  // Replace anything that is not a letter or a number with an empty string
+  const cleanedStr = transformedStr.replace(/[^a-z0-9A-Z]/g, "");
+
   // Return the transformed string
-  return transformedStr;
+  return cleanedStr;
 }
 
 const handleOnSubmit = (v, isEdit) => {


### PR DESCRIPTION
As Joe pointed out submitting a blog with these characters: [ ] in the title does not work since they are not valid characters in the keys of the social contract. I made a small change to only allow numbers, capital and lowercase letters. Everything else is replace in the title by an empty string. That is done by this regex: `/[^a-z0-9A-Z]/g`