### PR TITLE
fix(proposal): should show the proposal you submitted and not the previous

### DIFF
--- a/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
@@ -431,6 +431,7 @@ useEffect(() => {
         "${REPL_DEVHUB_CONTRACT}",
         "get_all_proposal_ids"
       );
+      console.log("PROPOSAL_IDS", proposalIds);
       if (Array.isArray(proposalIds) && !proposalIdsArray) {
         setProposalIdsArray(proposalIds);
       }

--- a/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
@@ -431,7 +431,6 @@ useEffect(() => {
         "${REPL_DEVHUB_CONTRACT}",
         "get_all_proposal_ids"
       );
-      console.log("PROPOSAL_IDS", proposalIds);
       if (Array.isArray(proposalIds) && !proposalIdsArray) {
         setProposalIdsArray(proposalIds);
       }

--- a/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
@@ -439,9 +439,23 @@ useEffect(() => {
         Array.isArray(proposalIdsArray) &&
         proposalIds.length !== proposalIdsArray.length
       ) {
-        setCreateTxn(false);
-        setProposalId(proposalIds[proposalIds.length - 1]);
-        setShowProposalPage(true);
+        const latestProposalId = proposalIds[proposalIds.length - 1];
+        const latestProposal = Near.view(
+          "${REPL_DEVHUB_CONTRACT}",
+          "get_proposal",
+          {
+            proposal_id: latestProposalId,
+          }
+        );
+
+        if (
+          latestProposal.snapshot.name === title &&
+          latestProposal.snapshot.description === description
+        ) {
+          setCreateTxn(false);
+          setProposalId(proposalIds[proposalIds.length - 1]);
+          setShowProposalPage(true);
+        }
       }
     }
   }

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -152,10 +152,10 @@ test.describe("Don't ask again enabled", () => {
           const response = await route.fetch();
           const json = await response.json();
 
-          await new Promise((resolve) => setTimeout(() => resolve(), 2000));
+          await new Promise((resolve) => setTimeout(() => resolve(), 4000));
           const resultObj = decodeResultJSON(json.result.result);
+          newProposalId = resultObj[resultObj.length - 1] + 1;
           if (transaction_completed) {
-            newProposalId = resultObj[resultObj.length - 1] + 1;
             resultObj.push(newProposalId);
           }
           console.log("get_all_proposal_ids", JSON.stringify(resultObj));
@@ -164,13 +164,12 @@ test.describe("Don't ask again enabled", () => {
           await route.fulfill({ response, json });
         } else if (
           postData.params?.method_name === "get_proposal" &&
-          newProposalId > 0
+          postData.params.args_base64 ===
+            btoa(JSON.stringify({ proposal_id: newProposalId }))
         ) {
-          console.log("GET_PROPOSAL", newProposalId);
           postData.params.args_base64 = btoa(
             JSON.stringify({ proposal_id: newProposalId - 1 })
           );
-
           const response = await route.fetch({
             postData: JSON.stringify(postData),
           });

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -182,6 +182,13 @@ test.describe("Don't ask again enabled", () => {
     await expect(
       await page.getByRole("button", { name: "Edit" })
     ).toBeVisible();
+
+    await expect(
+      await page.locator(
+        '[data-component="devhub.near/widget/devhub.entity.proposal.StatusTag"]'
+      )
+    ).toHaveText("DRAFT");
+
     await pauseIfVideoRecording(page);
   });
 });

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -152,6 +152,7 @@ test.describe("Don't ask again enabled", () => {
           const response = await route.fetch();
           const json = await response.json();
 
+          await new Promise((resolve) => setTimeout(() => resolve(), 2000));
           const resultObj = decodeResultJSON(json.result.result);
           if (transaction_completed) {
             newProposalId = resultObj[resultObj.length - 1] + 1;

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -263,6 +263,177 @@ test.describe("Don't ask again enabled", () => {
 
     await pauseIfVideoRecording(page);
   });
+  test("should create a proposal without dont ask again cache values set", async ({
+    page,
+    account,
+  }) => {
+    test.setTimeout(120000);
+    await page.goto(`/${account}/widget/app?page=proposals`);
+
+    await page.getByRole("button", { name: " Submit Proposal" }).click();
+
+    const titleArea = await page.getByRole("textbox").first();
+    await titleArea.fill("Test proposal 123456");
+    await titleArea.blur();
+    await pauseIfVideoRecording(page);
+
+    const categoryDropdown = await page.locator(".dropdown-toggle").first();
+    await categoryDropdown.click();
+    await page.locator(".dropdown-menu > div > div:nth-child(2) > div").click();
+
+    const disabledSubmitButton = await page.locator(
+      ".submit-draft-button.disabled"
+    );
+
+    const summary = await page.locator('textarea[type="text"]');
+    await summary.fill("Test proposal summary 123456789");
+    await summary.blur();
+    await pauseIfVideoRecording(page);
+
+    const descriptionArea = await page
+      .frameLocator("iframe")
+      .locator(".CodeMirror textarea");
+    await descriptionArea.focus();
+    await descriptionArea.fill("The test proposal description.");
+    await descriptionArea.blur();
+    await pauseIfVideoRecording(page);
+
+    await page.locator('input[type="text"]').nth(2).fill("1000");
+    await pauseIfVideoRecording(page);
+    await page.getByRole("checkbox").first().click();
+    await pauseIfVideoRecording(page);
+    await expect(disabledSubmitButton).toBeAttached();
+    await page.getByRole("checkbox").nth(1).click();
+    await pauseIfVideoRecording(page);
+    await expect(disabledSubmitButton).not.toBeAttached();
+
+    let newProposalId = 0;
+    await mockTransactionSubmitRPCResponses(
+      page,
+      async ({ route, request, transaction_completed, last_receiver_id }) => {
+        const postData = request.postDataJSON();
+        if (
+          transaction_completed &&
+          postData.params?.method_name === "get_all_proposal_ids"
+        ) {
+          const response = await route.fetch();
+          const json = await response.json();
+
+          console.log(
+            "transaction completed, modifying get_proposal_ids result"
+          );
+          const resultObj = decodeResultJSON(json.result.result);
+          newProposalId = resultObj[resultObj.length - 1] + 1;
+          resultObj.push(newProposalId);
+          console.log(JSON.stringify(resultObj));
+          json.result.result = encodeResultJSON(resultObj);
+
+          await route.fulfill({ response, json });
+        } else if (
+          postData.params?.method_name === "get_proposal" &&
+          newProposalId > 0
+        ) {
+          console.log("GET_PROPOSAL", newProposalId);
+          postData.params.args_base64 = btoa(
+            JSON.stringify({ proposal_id: newProposalId - 1 })
+          );
+          console.log("GET_PROPOSAL 2", JSON.stringify(postData));
+          const response = await route.fetch({
+            postData: JSON.stringify(postData),
+          });
+          const json = await response.json();
+
+          console.log("GET_PROPOSAL 22", JSON.stringify(json));
+          let resultObj = decodeResultJSON(json.result.result);
+          console.log("GET_PROPOSAL 3", JSON.stringify(resultObj));
+
+          resultObj = {
+            proposal_version: "V0",
+            id: newProposalId,
+            author_id: "petersalomonsen.near",
+            social_db_post_block_height: "128860426",
+            snapshot: {
+              editor_id: "petersalomonsen.near",
+              timestamp: "1727265468109441208",
+              labels: [],
+              proposal_body_version: "V2",
+              name: "Develop stuff",
+              category: "DevDAO Platform",
+              summary: "summary",
+              description: "description",
+              linked_proposals: [],
+              requested_sponsorship_usd_amount: "2500",
+              requested_sponsorship_paid_in_currency: "USDT",
+              receiver_account: "petersalomonsen.near",
+              requested_sponsor: "neardevdao.near",
+              supervisor: "theori.near",
+              timeline: {
+                timeline_version: "V1",
+                status: "DRAFT",
+                sponsor_requested_review: false,
+                reviewer_completed_attestation: false,
+                kyc_verified: false,
+              },
+              linked_rfp: null,
+            },
+            snapshot_history: [
+              {
+                editor_id: "petersalomonsen.near",
+                timestamp: "1727265421865873611",
+                labels: [],
+                proposal_body_version: "V0",
+                name: "Develop stuff",
+                category: "DevDAO Platform",
+                summary: "summary",
+                description: "description",
+                linked_proposals: [],
+                requested_sponsorship_usd_amount: "2500",
+                requested_sponsorship_paid_in_currency: "USDT",
+                receiver_account: "petersalomonsen.near",
+                requested_sponsor: "neardevdao.near",
+                supervisor: "theori.near",
+                timeline: {
+                  status: "DRAFT",
+                },
+              },
+            ],
+          };
+
+          json.result.result = encodeResultJSON(resultObj);
+
+          await route.fulfill({ response, json });
+        } else {
+          await route.continue();
+        }
+      }
+    );
+
+    const submitButton = await page.getByText("Submit Draft");
+    await submitButton.scrollIntoViewIfNeeded();
+    await submitButton.hover();
+    await pauseIfVideoRecording(page);
+    await submitButton.click();
+    await expect(disabledSubmitButton).toBeAttached();
+
+    const loadingIndicator = await page.locator(
+      ".submit-proposal-draft-loading-indicator"
+    );
+    await expect(loadingIndicator).toBeAttached();
+
+    await page.getByRole("button", { name: "Confirm" }).click();
+
+    await loadingIndicator.waitFor({ state: "detached", timeout: 10000 });
+    await expect(loadingIndicator).not.toBeVisible();
+
+    await expect(
+      await page.getByRole("button", { name: "Edit" })
+    ).toBeVisible();
+
+    await expect(await page.getByText(`#${newProposalId}`)).toBeVisible();
+    await expect(await page.getByText("DRAFT", { exact: true })).toBeVisible();
+
+    await pauseIfVideoRecording(page);
+  });
 });
 
 test.describe('Moderator with "Don\'t ask again" enabled', () => {

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -119,10 +119,6 @@ test.describe("Don't ask again enabled", () => {
     await categoryDropdown.click();
     await page.locator(".dropdown-menu > div > div:nth-child(2) > div").click();
 
-    const disabledSubmitButton = await page.locator(
-      ".submit-draft-button.disabled"
-    );
-
     const summary = await page.locator('textarea[type="text"]');
     await summary.fill("Test proposal summary 123456789");
     await summary.blur();
@@ -141,6 +137,11 @@ test.describe("Don't ask again enabled", () => {
     await pauseIfVideoRecording(page);
     await page.getByRole("checkbox").first().click();
     await pauseIfVideoRecording(page);
+
+    const disabledSubmitButton = await page.locator(
+      ".submit-draft-button.disabled"
+    );
+
     await expect(disabledSubmitButton).toBeAttached();
     await page.getByRole("checkbox").nth(1).click();
     await pauseIfVideoRecording(page);

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -108,8 +108,10 @@ test.describe("Don't ask again enabled", () => {
 
     await page.getByRole("button", { name: " Submit Proposal" }).click();
 
+    const proposalTitle = "Test proposal 123456";
+    const proposalDescription = "The test proposal description.";
     const titleArea = await page.getByRole("textbox").first();
-    await titleArea.fill("Test proposal 123456");
+    await titleArea.fill(proposalTitle);
     await titleArea.blur();
     await pauseIfVideoRecording(page);
 
@@ -130,11 +132,12 @@ test.describe("Don't ask again enabled", () => {
       .frameLocator("iframe")
       .locator(".CodeMirror textarea");
     await descriptionArea.focus();
-    await descriptionArea.fill("The test proposal description.");
+    await descriptionArea.fill(proposalDescription);
     await descriptionArea.blur();
     await pauseIfVideoRecording(page);
 
-    await page.locator('input[type="text"]').nth(2).fill("1000");
+    const proposalAmount = "1000";
+    await page.locator('input[type="text"]').nth(2).fill(proposalAmount);
     await pauseIfVideoRecording(page);
     await page.getByRole("checkbox").first().click();
     await pauseIfVideoRecording(page);
@@ -187,12 +190,12 @@ test.describe("Don't ask again enabled", () => {
               timestamp: "1727265468109441208",
               labels: [],
               proposal_body_version: "V2",
-              name: "Develop stuff",
+              name: proposalTitle,
               category: "DevDAO Platform",
               summary: "summary",
-              description: "description",
+              description: proposalDescription,
               linked_proposals: [],
-              requested_sponsorship_usd_amount: "2500",
+              requested_sponsorship_usd_amount: proposalAmount,
               requested_sponsorship_paid_in_currency: "USDT",
               receiver_account: "petersalomonsen.near",
               requested_sponsor: "neardevdao.near",
@@ -212,12 +215,12 @@ test.describe("Don't ask again enabled", () => {
                 timestamp: "1727265421865873611",
                 labels: [],
                 proposal_body_version: "V0",
-                name: "Develop stuff",
+                name: proposalTitle,
                 category: "DevDAO Platform",
                 summary: "summary",
-                description: "description",
+                description: proposalDescription,
                 linked_proposals: [],
-                requested_sponsorship_usd_amount: "2500",
+                requested_sponsorship_usd_amount: proposalAmount,
                 requested_sponsorship_paid_in_currency: "USDT",
                 receiver_account: "petersalomonsen.near",
                 requested_sponsor: "neardevdao.near",

--- a/playwright-tests/util/cache.js
+++ b/playwright-tests/util/cache.js
@@ -84,8 +84,8 @@ export async function setCacheValue({ page, key, value }) {
   );
 }
 
-export async function getCacheValue(key) {
-  const storedData = await page.evaluate(async (key) => {
+export async function getCacheValue(page, key) {
+  return await page.evaluate(async (key) => {
     return await new Promise((resolve) => {
       const dbName = "cacheDb";
       const storeName = "cache-v1";


### PR DESCRIPTION
After submitting a proposal draft, all the proposal ids are fetched from the contract to check if a new was added. The problem is that NearSocialVM will cache the results of `get_all_proposals_ids` from the previous time that you submitted, and then when cache is invalidated, the first result will return a different number of proposal_ids in case someone submitted a proposal after the last time you did ( which is most often the case ).

To fix this issue, an additional check is added to check that the latest proposal title and description matches what you submitted. This way not only the number of proposal ids is enough to accept that the latest proposal id is the one you submitted, but also it must match the title and description.

This Pull Request adds a playwright test for the scenario, which will break if the fix is reverted.

Here's a video of the test failing, without the fix:


https://github.com/user-attachments/assets/1aa63ea1-78c4-4a38-960d-61e7ad821361

And here's a video of the test passing, with the fix:


https://github.com/user-attachments/assets/a76de7b5-93d5-4b98-b059-66b53c82e0d8



fixes #936 