### PR TITLE
fix that submit draft keeps on spinning

### DIFF
--- a/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/Editor.jsx
@@ -410,6 +410,31 @@ const InputContainer = ({ heading, description, children }) => {
   );
 };
 
+function checkIfLatestProposalMatchesTitleAndDescription() {
+  Near.asyncView("${REPL_DEVHUB_CONTRACT}", "get_all_proposal_ids").then(
+    (proposalIds) => {
+      const latestProposalId = proposalIds[proposalIds.length - 1];
+      Near.asyncView("${REPL_DEVHUB_CONTRACT}", "get_proposal", {
+        proposal_id: latestProposalId,
+      }).then((latestProposal) => {
+        if (
+          latestProposal.snapshot.name === title &&
+          latestProposal.snapshot.description === description
+        ) {
+          setCreateTxn(false);
+          setProposalId(proposalIds[proposalIds.length - 1]);
+          setShowProposalPage(true);
+        } else {
+          setTimeout(
+            () => checkIfLatestProposalMatchesTitleAndDescription(),
+            500
+          );
+        }
+      });
+    }
+  );
+}
+
 // show proposal created after txn approval for popup wallet
 useEffect(() => {
   if (isTxnCreated) {
@@ -427,36 +452,7 @@ useEffect(() => {
         setShowProposalPage(true);
       }
     } else {
-      const proposalIds = Near.view(
-        "${REPL_DEVHUB_CONTRACT}",
-        "get_all_proposal_ids"
-      );
-      if (Array.isArray(proposalIds) && !proposalIdsArray) {
-        setProposalIdsArray(proposalIds);
-      }
-      if (
-        Array.isArray(proposalIds) &&
-        Array.isArray(proposalIdsArray) &&
-        proposalIds.length !== proposalIdsArray.length
-      ) {
-        const latestProposalId = proposalIds[proposalIds.length - 1];
-        const latestProposal = Near.view(
-          "${REPL_DEVHUB_CONTRACT}",
-          "get_proposal",
-          {
-            proposal_id: latestProposalId,
-          }
-        );
-
-        if (
-          latestProposal.snapshot.name === title &&
-          latestProposal.snapshot.description === description
-        ) {
-          setCreateTxn(false);
-          setProposalId(proposalIds[proposalIds.length - 1]);
-          setShowProposalPage(true);
-        }
-      }
+      checkIfLatestProposalMatchesTitleAndDescription();
     }
   }
 });

--- a/instances/events-committee.near/widget/devhub/entity/proposal/Editor.jsx
+++ b/instances/events-committee.near/widget/devhub/entity/proposal/Editor.jsx
@@ -413,6 +413,31 @@ const InputContainer = ({ heading, description, children }) => {
   );
 };
 
+function checkIfLatestProposalMatchesTitleAndDescription() {
+  Near.asyncView("${REPL_EVENTS_CONTRACT}", "get_all_proposal_ids").then(
+    (proposalIds) => {
+      const latestProposalId = proposalIds[proposalIds.length - 1];
+      Near.asyncView("${REPL_EVENTS_CONTRACT}", "get_proposal", {
+        proposal_id: latestProposalId,
+      }).then((latestProposal) => {
+        if (
+          latestProposal.snapshot.name === title &&
+          latestProposal.snapshot.description === description
+        ) {
+          setCreateTxn(false);
+          setProposalId(proposalIds[proposalIds.length - 1]);
+          setShowProposalPage(true);
+        } else {
+          setTimeout(
+            () => checkIfLatestProposalMatchesTitleAndDescription(),
+            500
+          );
+        }
+      });
+    }
+  );
+}
+
 // show proposal created after txn approval for popup wallet
 useEffect(() => {
   if (isTxnCreated) {
@@ -430,36 +455,7 @@ useEffect(() => {
         setShowProposalPage(true);
       }
     } else {
-      const proposalIds = Near.view(
-        "${REPL_EVENTS_CONTRACT}",
-        "get_all_proposal_ids"
-      );
-      if (Array.isArray(proposalIds) && !proposalIdsArray) {
-        setProposalIdsArray(proposalIds);
-      }
-      if (
-        Array.isArray(proposalIds) &&
-        Array.isArray(proposalIdsArray) &&
-        proposalIds.length !== proposalIdsArray.length
-      ) {
-        const latestProposalId = proposalIds[proposalIds.length - 1];
-        const latestProposal = Near.view(
-          "${REPL_DEVHUB_CONTRACT}",
-          "get_proposal",
-          {
-            proposal_id: latestProposalId,
-          }
-        );
-
-        if (
-          latestProposal.snapshot.name === title &&
-          latestProposal.snapshot.description === description
-        ) {
-          setCreateTxn(false);
-          setProposalId(proposalIds[proposalIds.length - 1]);
-          setShowProposalPage(true);
-        }
-      }
+      checkIfLatestProposalMatchesTitleAndDescription();
     }
   }
   setLoading(false);

--- a/playwright-tests/tests/proposal/proposals.spec.js
+++ b/playwright-tests/tests/proposal/proposals.spec.js
@@ -154,6 +154,7 @@ test.describe("Don't ask again enabled", () => {
     await expect(disabledSubmitButton).not.toBeAttached();
 
     let newProposalId = 0;
+    let get_all_proposal_ids_attempt = 0;
     await mockTransactionSubmitRPCResponses(
       page,
       async ({ route, request, transaction_completed, last_receiver_id }) => {
@@ -162,11 +163,14 @@ test.describe("Don't ask again enabled", () => {
           const response = await route.fetch();
           const json = await response.json();
 
-          await new Promise((resolve) => setTimeout(() => resolve(), 4000));
           const resultObj = decodeResultJSON(json.result.result);
           newProposalId = resultObj[resultObj.length - 1] + 1;
           if (transaction_completed) {
-            resultObj.push(newProposalId);
+            if (get_all_proposal_ids_attempt === 1) {
+              resultObj.push(newProposalId);
+            } else {
+              get_all_proposal_ids_attempt++;
+            }
           }
           json.result.result = encodeResultJSON(resultObj);
 


### PR DESCRIPTION
Based on the report that some user only saw the submit button spinner keeping on spinning, which I assume is as reproduced in the test that can be seen in the video here:

https://github.com/user-attachments/assets/04d0e6f2-9d65-458e-95cd-729bce1173a4

The test reproduces a scenario where the transaction completes, but the view call for getting all proposal ids does not show the latest proposal immediately, which might happen in the case the transaction is not fully finalized. The previous implementation will then just keep on spinning, and so it is assumed that this is what the user experienced.

By retrying checking for the latest proposal until it matches the submitted title and description, the submitted proposal will be found eventually, and the submit button will stop spinning, and the new proposal should display.

With the fix, the submit button stops spinning, and the submitted proposal is displayed:

https://github.com/user-attachments/assets/8eef24db-f08b-450f-8b52-548a133af94c


