### PR TITLE
feat: Added KYC expiration support

### DIFF
--- a/instances/devhub.near/widget/devhub/entity/proposal/VerificationStatus.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/VerificationStatus.jsx
@@ -31,7 +31,7 @@ useEffect(() => {
           break;
         case "NOT_SUBMITTED":
         case "REJECTED":
-          displayableText = "Not Verfied";
+          displayableText = "Not Verified";
           break;
         default:
           displayableText = "Failed to get status";

--- a/instances/devhub.near/widget/devhub/entity/proposal/VerificationStatus.jsx
+++ b/instances/devhub.near/widget/devhub/entity/proposal/VerificationStatus.jsx
@@ -16,18 +16,21 @@ useEffect(() => {
     (receiverAccount ?? "").includes(".tg")
   ) {
     asyncFetch(
-      `https://neardevhub-kyc-proxy.shuttleapp.rs/kyc/${receiverAccount}`
+      `https://neardevhub-kyc-proxy-gvbr.shuttle.app/kyc/${receiverAccount}`
     ).then((res) => {
       let displayableText = "";
       switch (res.body.kyc_status) {
-        case "Approved":
+        case "APPROVED":
           displayableText = "Verified";
           break;
-        case "Pending":
+        case "PENDING":
           displayableText = "Pending";
           break;
-        case "NotSubmitted":
-        case "Rejected":
+        case "EXPIRED":
+          displayableText = "Expired";
+          break;
+        case "NOT_SUBMITTED":
+        case "REJECTED":
           displayableText = "Not Verfied";
           break;
         default:

--- a/instances/events-committee.near/widget/devhub/entity/proposal/VerificationStatus.jsx
+++ b/instances/events-committee.near/widget/devhub/entity/proposal/VerificationStatus.jsx
@@ -39,6 +39,8 @@ useEffect(() => {
       }
       setVerificationStatus(displayableText);
     });
+  } else {
+    setVerificationStatus("Invalid receipient wallet address");
   }
 }, [receiverAccount]);
 

--- a/instances/events-committee.near/widget/devhub/entity/proposal/VerificationStatus.jsx
+++ b/instances/events-committee.near/widget/devhub/entity/proposal/VerificationStatus.jsx
@@ -15,28 +15,30 @@ useEffect(() => {
     (receiverAccount ?? "").includes(".near") ||
     (receiverAccount ?? "").includes(".tg")
   ) {
-    useCache(
-      () =>
-        asyncFetch(
-          `https://neardevhub-kyc-proxy.shuttleapp.rs/kyc/${receiverAccount}`
-        ).then((res) => {
-          let displayableText = "";
-          switch (res.body.kyc_status) {
-            case "Approved":
-              displayableText = "Verified";
-              break;
-            case "Pending":
-              displayableText = "Pending";
-              break;
-            default:
-              displayableText = "Not Verfied";
-              break;
-          }
-          setVerificationStatus(displayableText);
-        }),
-      "ky-check-proposal" + receiverAccount,
-      { subscribe: false }
-    );
+    asyncFetch(
+      `https://neardevhub-kyc-proxy-gvbr.shuttle.app/kyc/${receiverAccount}`
+    ).then((res) => {
+      let displayableText = "";
+      switch (res.body.kyc_status) {
+        case "APPROVED":
+          displayableText = "Verified";
+          break;
+        case "PENDING":
+          displayableText = "Pending";
+          break;
+        case "EXPIRED":
+          displayableText = "Expired";
+          break;
+        case "NOT_SUBMITTED":
+        case "REJECTED":
+          displayableText = "Not Verfied";
+          break;
+        default:
+          displayableText = "Failed to get status";
+          break;
+      }
+      setVerificationStatus(displayableText);
+    });
   }
 }, [receiverAccount]);
 
@@ -233,21 +235,29 @@ const VerificationBtn = () => {
 
 return (
   <div>
-    <div className="d-flex text-black justify-content-between align-items-center">
-      <div className="d-flex" style={{ gap: "12px" }}>
-        <img
-          className="align-self-center object-fit-cover"
-          src={verificationStatus === "Verified" ? SuccessImg : WarningImg}
-          height={imageSize}
-        />
-        <div className="d-flex flex-column justify-content-center">
-          <div className="h6 mb-0">Fractal</div>
-          <div className="text-sm text-muted">{verificationStatus}</div>
+    {!verificationStatus ? (
+      <span
+        className="spinner-grow spinner-grow-sm me-1"
+        role="status"
+        aria-hidden="true"
+      />
+    ) : (
+      <div className="d-flex text-black justify-content-between align-items-center">
+        <div className="d-flex" style={{ gap: "12px" }}>
+          <img
+            className="align-self-center object-fit-cover"
+            src={verificationStatus === "Verified" ? SuccessImg : WarningImg}
+            height={imageSize}
+          />
+          <div className="d-flex flex-column justify-content-center">
+            <div className="h6 mb-0">Fractal</div>
+            <div className="text-sm text-muted">{verificationStatus}</div>
+          </div>
         </div>
+        {verificationStatus !== "Verified" && showGetVerifiedBtn && (
+          <VerificationBtn />
+        )}
       </div>
-      {verificationStatus !== "Verified" && showGetVerifiedBtn && (
-        <VerificationBtn />
-      )}
-    </div>
+    )}
   </div>
 );

--- a/instances/events-committee.near/widget/devhub/entity/proposal/VerificationStatus.jsx
+++ b/instances/events-committee.near/widget/devhub/entity/proposal/VerificationStatus.jsx
@@ -31,7 +31,7 @@ useEffect(() => {
           break;
         case "NOT_SUBMITTED":
         case "REJECTED":
-          displayableText = "Not Verfied";
+          displayableText = "Not Verified";
           break;
         default:
           displayableText = "Failed to get status";


### PR DESCRIPTION
The [backend has been migrated](https://github.com/NEAR-DevHub/neardevhub-kyc-proxy/commit/3758c891a36261360a3e0d3de47e30d7064c9b66) to the new Shuttle infrastructure, so the URL has changed (the old URL is still active and runs the old version of the code).

The reported KYC status is now in SCREAMING_SNAKE_CASE and a new `EXPIRED` status is added.

I have also upgraded events-committee code (copied the whole component)

@race-of-sloths include