### PR TITLE
Upgrade playwright to fix tests

### DIFF
--- a/.github/workflows/continuous-integration-workflow-events.yml
+++ b/.github/workflows/continuous-integration-workflow-events.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - name: Upgrade Playwright
-        run: npm i -g @playwright/test@latest
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/continuous-integration-workflow-events.yml
+++ b/.github/workflows/continuous-integration-workflow-events.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm run fmt:check
   playwright-tests-proposal:
     name: Proposal - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -40,7 +40,7 @@ jobs:
           INSTANCE=events npx playwright test --project=events playwright-tests/tests/proposal
   playwright-tests-events:
     name: Events Committee - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -51,8 +51,7 @@ jobs:
         run: |
           npm ci
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mpeterdev/bos-loader/releases/download/v0.7.1/bos-loader-v0.7.1-installer.sh | sh
-          npx playwright install-deps
-          npx playwright install
+          npx playwright install --with-deps
       - name: Run tests
         run: |
           INSTANCE=events npx playwright test --project=events playwright-tests/tests/events

--- a/.github/workflows/continuous-integration-workflow-events.yml
+++ b/.github/workflows/continuous-integration-workflow-events.yml
@@ -28,12 +28,13 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
+      - name: Upgrade Playwright
+        run: npm i -g @playwright/test@latest
       - name: Install dependencies
         run: |
           npm ci
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mpeterdev/bos-loader/releases/download/v0.7.1/bos-loader-v0.7.1-installer.sh | sh
-          npx playwright install-deps
-          npx playwright install
+          npx playwright install --with-deps
       - name: Run tests
         run: |
           INSTANCE=events npx playwright test --project=events playwright-tests/tests/proposal

--- a/.github/workflows/continuous-integration-workflow-infra.yml
+++ b/.github/workflows/continuous-integration-workflow-infra.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm run fmt:check
   playwright-tests-proposal:
     name: Proposal - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -39,7 +39,7 @@ jobs:
           INSTANCE=infrastructure npx playwright test --project=infrastructure playwright-tests/tests/proposal/comment.spec.js
   playwright-tests-infra:
     name: Infrastructure Committee - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm run fmt:check
   playwright-tests-blog:
     name: Blog - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -39,7 +39,7 @@ jobs:
           INSTANCE=devhub npx playwright test --project=devhub playwright-tests/tests/blog
   playwright-tests-community:
     name: Community - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -57,7 +57,7 @@ jobs:
           INSTANCE=devhub npx playwright test --project=devhub playwright-tests/tests/community
   playwright-tests-other:
     name: Other - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -75,7 +75,7 @@ jobs:
           INSTANCE=devhub npx playwright test --project=devhub playwright-tests/tests/other
   playwright-tests-proposal:
     name: Proposal - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -93,7 +93,7 @@ jobs:
           INSTANCE=devhub npx playwright test --project=devhub playwright-tests/tests/proposal
   playwright-tests-sunset:
     name: Sunset - Playwright tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Updated ubuntu to use `22.04`, since playwright fails to get installed on later versions as mentioned [here](https://github.com/microsoft/playwright/issues/30368#issuecomment-2669259798). I tried upgrading playwright but the same error.